### PR TITLE
Separated raw UART interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,20 +9,24 @@ OBJDUMP	= $(P)objdump
 CFLAGS	= -O -Wall -Werror -DPIC32MZ
 LDFLAGS	= -T pic32mz.ld -e _start -Wl,-Map=pic32mz.map
 
-PROG = uart
+PROGNAME = main
+SOURCES = main.c uart_raw.c
+OBJECTS := $(SOURCES:.c=.o)
 
-all: $(PROG).srec
+all: $(PROGNAME).srec
 
-$(PROG).srec: $(PROG).c
+$(PROGNAME).srec: $(OBJECTS)
+	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBS) -o $(PROGNAME).elf
+	$(OBJCOPY) -O srec $(PROGNAME).elf $(PROGNAME).srec
+
+%.o: %.c
 	$(CC) $(CFLAGS) -c $<
-	$(CC) $(LDFLAGS) $(PROG).o $(LIBS) -o $(PROG).elf
-	$(OBJCOPY) -O srec $(PROG).elf $(PROG).srec
 
-debug: $(PROG).srec
-	$(GDB) $(PROG).elf
+debug: $(PROGNAME).srec
+	$(GDB) $(PROGNAME).elf
 
-qemu: $(PROG).srec
-	$(QEMU) -kernel $(PROG).srec
+qemu: $(PROGNAME).srec
+	$(QEMU) -kernel $(PROGNAME).srec
 
 clean:
 	rm -f *.o *.lst *~ *.elf *.srec *.map

--- a/global_config.h
+++ b/global_config.h
@@ -1,0 +1,7 @@
+#ifndef GLOBAL_CONFIG_H
+#define GLOBAL_CONFIG_H
+
+#define MHZ     200             /* CPU clock. */
+
+
+#endif // GLOBAL_CONFIG_H

--- a/uart_raw.c
+++ b/uart_raw.c
@@ -1,0 +1,80 @@
+#include "pic32mz.h"
+#include "uart_raw.h"
+#include "global_config.h"
+
+void uart_init(){
+    /* Initialize UART. */
+    U1RXR = 2;                          /* assign UART1 receive to pin RPF4 */
+    RPF5R = 1;                          /* assign pin RPF5 to UART1 transmit */
+
+    U1BRG = PIC32_BRG_BAUD (MHZ * 500000, 115200);
+    U1STA = 0;
+    U1MODE = PIC32_UMODE_PDSEL_8NPAR |      /* 8-bit data, no parity */
+             PIC32_UMODE_ON;                /* UART Enable */
+    U1STASET = PIC32_USTA_URXEN |           /* Receiver Enable */
+               PIC32_USTA_UTXEN;            /* Transmit Enable */
+
+}
+
+void uart_putch(unsigned char c){
+    /* Wait for transmitter shift register empty. */
+    while (! (U1STA & PIC32_USTA_TRMT))
+        continue;
+again:
+    /* Send byte. */
+    U1TXREG = c;
+
+    /* Wait for transmitter shift register empty. */
+    while (! (U1STA & PIC32_USTA_TRMT))
+        continue;
+
+    if (c == '\n') {
+        c = '\r';
+        goto again;
+    }
+
+}
+
+void uart_putstr(const char* str){
+  while(*str) uart_putch(*str++);
+}
+
+/* Helper function for displaying hex values/ */
+static int hexchar (unsigned val)
+{
+    return "0123456789abcdef" [val & 0xf];
+}
+
+
+void uart_puthex(unsigned value){
+    uart_putch (hexchar (value >> 28));
+    uart_putch (hexchar (value >> 24));
+    uart_putch (hexchar (value >> 20));
+    uart_putch (hexchar (value >> 16));
+    uart_putch (hexchar (value >> 12));
+    uart_putch (hexchar (value >> 8));
+    uart_putch (hexchar (value >> 4));
+    uart_putch (hexchar (value));
+}
+
+unsigned char uart_getch(){
+      unsigned c;
+
+    for (;;) {
+        /* Wait until receive data available. */
+        if (U1STA & PIC32_USTA_URXDA) {
+            c = (unsigned char) U1RXREG;
+            break;
+        }
+    }
+    return c;
+}
+
+
+void uart_printreg(const char* p, unsigned value){
+    uart_putstr (p);
+    uart_putch ('=');
+    uart_putch (' ');
+    uart_puthex (value);
+    uart_putch ('\n');
+}

--- a/uart_raw.h
+++ b/uart_raw.h
@@ -1,0 +1,34 @@
+#ifndef UART_RAW_H
+#define UART_RAW_H
+
+/* Raw UART interface. Useful for debugging.
+ * A higher-level solution will have to be implemented eventually,
+ *  but temporarily this should be fine.
+ */
+
+
+/* This procedure initializes UART. It must be called (once) before
+ * any other uart_* functions. */
+void uart_init();
+
+/* Transmits a single byte via UART1. */
+void uart_putch(unsigned char c);
+/* Transmits a character string via UART1. */
+void uart_putstr(const char* str);
+/* Transmits a 32it number in hex format via UART1. */
+void uart_puthex(unsigned value);
+
+/* Receives a single byte from UART.
+ * This function blocks execution until a byte is available.
+ */
+unsigned char uart_getch();
+
+/* This function is a convenience for displaying register values
+ * over UART.
+ * @param prefix: A string with the name of the displayed register.
+ *                The name will be outputted before the value.
+ * @param value: An unsigned 32bit value to display.
+ */
+void uart_printreg(const char* prefix, unsigned value);
+
+#endif // UART_RAW_H


### PR DESCRIPTION
Since UART is probably going to be very useful for debugging, I moved raw access implementation to a separate file, cleaned it up a little bit, and added few convenience procedures.

`uart_raw.h` provides a simple interface for basic UART operations.

The `Makefile` is modified so that it supports compiling multiple translation units.

