### PR TITLE
Reorganized startup procedure as specified in #2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,29 @@
 P	= mips-mti-elf-
 QEMU	= qemu-system-mipsel -machine pic32mz-wifire -sdl -serial stdio -s -S
 CC	= $(P)gcc -mips32r2 -EL -g -nostdlib
+AS	= $(P)as -mips32r2 -EL -g
 GDB	= $(P)gdb
 OBJCOPY	= $(P)objcopy
 OBJDUMP	= $(P)objdump
 CFLAGS	= -O -Wall -Werror -DPIC32MZ
-LDFLAGS	= -T pic32mz.ld -e _start -Wl,-Map=pic32mz.map
+LDSCRIPT= pic32mz.ld
+LDFLAGS	= -T $(LDSCRIPT) -e _start -Wl,-Map=pic32mz.map
 
 PROGNAME = main
 SOURCES = main.c uart_raw.c
+SOURCES_ASM = startup.s
 OBJECTS := $(SOURCES:.c=.o)
+OBJECTS_ASM := $(SOURCES_ASM:.s=.o)
+OBJECTS += $(OBJECTS_ASM)
 
 all: $(PROGNAME).srec
 
-$(PROGNAME).srec: $(OBJECTS)
+$(PROGNAME).srec: $(OBJECTS) $(LDSCRIPT)
 	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBS) -o $(PROGNAME).elf
 	$(OBJCOPY) -O srec $(PROGNAME).elf $(PROGNAME).srec
+
+%.S: %.c
+	$(AS) $(CFLAGS) -c $<
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ LDFLAGS	= -T $(LDSCRIPT) -Wl,-Map=pic32mz.map
 
 PROGNAME = main
 SOURCES = main.c uart_raw.c
-SOURCES_ASM = startup.s
+SOURCES_ASM = startup.S
 OBJECTS := $(SOURCES:.c=.o)
-OBJECTS_ASM := $(SOURCES_ASM:.s=.o)
+OBJECTS_ASM := $(SOURCES_ASM:.S=.o)
 OBJECTS += $(OBJECTS_ASM)
 
 all: $(PROGNAME).srec

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJCOPY	= $(P)objcopy
 OBJDUMP	= $(P)objdump
 CFLAGS	= -O -Wall -Werror -DPIC32MZ
 LDSCRIPT= pic32mz.ld
-LDFLAGS	= -T $(LDSCRIPT) -e _start -Wl,-Map=pic32mz.map
+LDFLAGS	= -T $(LDSCRIPT) -Wl,-Map=pic32mz.map
 
 PROGNAME = main
 SOURCES = main.c uart_raw.c

--- a/main.c
+++ b/main.c
@@ -5,6 +5,9 @@
 #include "uart_raw.h"
 #include "global_config.h"
 
+char str[] = "This is a global string!\n";
+char empty[100]; /* This should land in .bss and get cleared by _start procedure. */
+
 /*
  * Chip configuration.
  */
@@ -29,20 +32,6 @@ PIC32_DEVCFG (
     DEVCFG3_FETHIO |            /* Default Ethernet pins */
     DEVCFG3_USERID(0xffff));    /* User-defined ID */
 
-/*
- * Boot code at bfc00000.
- * Setup stack pointer and $gp registers, and jump to main().
- */
-asm ("          .section .exception");
-asm ("          .globl _start");
-asm ("          .type _start, function");
-asm ("_start:   la      $sp, _estack");
-asm ("          la      $ra, main");
-asm ("          la      $gp, _gp");
-asm ("          jr      $ra");
-asm ("          .text");
-asm ("_estack   = _end + 0x1000");
-
 static volatile unsigned loop;
 
 /*
@@ -65,7 +54,7 @@ void udelay (unsigned usec)
     }
 }
 
-int main()
+int kernel_main()
 {
     /* Initialize coprocessor 0. */
     mtc0 (C0_COUNT, 0, 0);
@@ -84,6 +73,16 @@ int main()
     /* Initialize UART. */
     uart_init();
     uart_putstr("Hello, UART!\n");
+
+    /* Demonstrate access to .data */
+    uart_putstr(str);
+
+    /* Test whether .bss appears to have been cleared. */
+    char* p = empty;
+    while(p < empty + sizeof(empty))
+      if(*p++ != 0x00)
+	uart_putstr("Apparently .bss was not cleared!\n");
+        // TODO: Exit main? Ignore?
     
     /*
      * Print initial state of control registers.

--- a/main.c
+++ b/main.c
@@ -80,9 +80,9 @@ int kernel_main()
     /* Test whether .bss appears to have been cleared. */
     char* p = empty;
     while(p < empty + sizeof(empty))
-      if(*p++ != 0x00)
-	uart_putstr("Apparently .bss was not cleared!\n");
-        // TODO: Exit main? Ignore?
+        if(*p++ != 0x00)
+            uart_putstr("Apparently .bss was not cleared!\n");
+            // TODO: Exit main? Ignore?
     
     /*
      * Print initial state of control registers.

--- a/pic32mz.ld
+++ b/pic32mz.ld
@@ -22,6 +22,7 @@ SECTIONS
     __text = ABSOLUTE(.);
     /* Exception handlers. */
     *(.exception)
+    . = 0x500;
     /* Execution starts here. */
     *(.init)
     *(.text .text.*)

--- a/pic32mz.ld
+++ b/pic32mz.ld
@@ -19,6 +19,7 @@ SECTIONS
 
   .text : AT(ORIGIN(flash))
   {
+    _text = ABSOLUTE(.);
     /* Exception handlers. */
     *(.exception)
     /* Execution starts here. */
@@ -49,6 +50,7 @@ SECTIONS
   .data : AT(ADDR(.text) + SIZEOF(.text))
   {
     __data_start = ABSOLUTE(.);
+    _data = ABSOLUTE(.);
     _gp = .; 	/* We have only 32k RAM on MC-24, so no need for 0x8000 offset. */
     *(.data .data.*)
     /* We want the small data sections together, so single-instruction offsets
@@ -61,6 +63,7 @@ SECTIONS
 
   .bss ADDR (.data) + SIZEOF (.data) (NOLOAD) :
   {
+    _bss = ABSOLUTE(.);
     __bss_start = ABSOLUTE(.);
     *(.sbss .scommon)
     *(.bss .bss.*)

--- a/pic32mz.ld
+++ b/pic32mz.ld
@@ -2,7 +2,7 @@
  * Linker script for PIC32MZ firmware.
  */
 OUTPUT_ARCH(mips)
-ENTRY(_reset_vector_)
+ENTRY(_start)
 MEMORY
 {
   flash   (rx)   : ORIGIN = 0xbfc00000,	LENGTH = 0xff00

--- a/pic32mz.ld
+++ b/pic32mz.ld
@@ -19,7 +19,7 @@ SECTIONS
 
   .text : AT(ORIGIN(flash))
   {
-    _text = ABSOLUTE(.);
+    __text = ABSOLUTE(.);
     /* Exception handlers. */
     *(.exception)
     /* Execution starts here. */
@@ -29,7 +29,7 @@ SECTIONS
     __rodata_start = ABSOLUTE(.);
     *(.rodata .rodata.*)
     __rodata_end = ABSOLUTE(.);
-    _etext = ABSOLUTE(.);
+    __etext = ABSOLUTE(.);
   } > flash
 
   /* Device configuration.  */
@@ -50,7 +50,7 @@ SECTIONS
   .data : AT(ADDR(.text) + SIZEOF(.text))
   {
     __data_start = ABSOLUTE(.);
-    _data = ABSOLUTE(.);
+    __data = ABSOLUTE(.);
     _gp = .; 	/* We have only 32k RAM on MC-24, so no need for 0x8000 offset. */
     *(.data .data.*)
     /* We want the small data sections together, so single-instruction offsets
@@ -58,19 +58,19 @@ SECTIONS
        we can shorten the on-disk segment size.  */
     *(.sdata .sdata.*)
     . = ALIGN(4);
-    _edata = ABSOLUTE(.);
+    __edata = ABSOLUTE(.);
   }
 
   .bss ADDR (.data) + SIZEOF (.data) (NOLOAD) :
   {
-    _bss = ABSOLUTE(.);
+    __bss = ABSOLUTE(.);
     __bss_start = ABSOLUTE(.);
     *(.sbss .scommon)
     *(.bss .bss.*)
     *(COMMON)
     . = ALIGN (4);
     __bss_end = ABSOLUTE(.);
-    _ebss = ABSOLUTE(.);
+    __ebss = ABSOLUTE(.);
   }
 
   _end = .;

--- a/startup.S
+++ b/startup.S
@@ -1,3 +1,5 @@
+#include <mips/m32c0.h>
+
 	.section .exception
 	.globl _start
 	.type _start, function
@@ -48,7 +50,7 @@ clear_bss:
 	/* Jump to kernel_main(). */
 	la $ra, kernel_main_exit # Set return address for kernel_main
     la      $t0, kernel_main
-    mtc0    $t0, $30      # Store kernel_main address as exception return address to ErrorEPC
+    mtc0    $t0, C0_ERRPC # Store kernel_main address as exception return address to ErrorEPC
 	eret				  # Exception return.
 
 kernel_main_exit:

--- a/startup.S
+++ b/startup.S
@@ -1,16 +1,16 @@
 #include <mips/m32c0.h>
 
-	.section .exception
-	.globl _start
-	.type _start, function
-	.set noreorder 	# Disable automatic instruction reordering.
+    .section .exception
+    .globl _start
+    .type _start, function
+    .set noreorder      // Disable automatic instruction reordering.
 
 .org 0x000
 .ent __reset_vector
 __reset_vector:
-	la $a0, _start	# Jump to _start.
-	jr $a0
-	  nop
+    la  $a0, _start     // Jump to _start.
+    jr  $a0
+      nop
 .end __reset_vector
 
 
@@ -18,46 +18,49 @@ __reset_vector:
 .org 0x500
 .ent _start
 _start:
-	la	$sp, _estack	# Set stack pointer.
-	la	$gp, _gp	# Prepare global pointer.
+    la  $sp, _estack    // Set stack pointer.
+    la  $gp, _gp        // Prepare global pointer.
 
 copy_rom_to_ram:
-	/* Copy .data from ROM to RAM.
-	 * .data is located in ROM just after .text, so it starts at _etext.
-	 * It should land at the beggining of RAM, which is pointed at by _data.
-	 * Copy words one by one, until _edata is reached. */
-	la	$t1, __data	# dest = _data
-	la	$t2, __edata	# dest_end = _edata
-	la	$t3, __etext	# src = _etext
+    /* Copy .data from ROM to RAM.
+     * .data is located in ROM just after .text, so it starts at _etext.
+     * It should land at the beggining of RAM, which is pointed at by _data.
+     * Copy words one by one, until _edata is reached. */
+#define t1_dest     $t1
+#define t2_dest_end $t2
+#define t3_src      $t3
+    la      t1_dest,     __data
+    la      t2_dest_end, __edata
+    la      t3_src,      __etext
 .Lcopy_next_word:
-	lw	$t0, 0($t3)	# x = *src
-	sw	$t0, 0($t1)	# *dest = x
-	addiu	$t1, 4		# dest++
-	bne	$t1, $t2, .Lcopy_next_word # jump if dest != dest_end
-	  addiu	$t3, 4		# src++
+    lw      $t0, 0(t3_src)
+    sw      $t0, 0(t1_dest)
+    addiu   t1_dest, 4
+    bne     t1_dest, t2_dest_end, .Lcopy_next_word
+     addiu  t3_src,  4
 
 clear_bss:
-	/*     Clear .bss. It starts at _bss and ends at _ebss. */
-	la	$t1, __bss	# dest = _bss
-	la	$t2, __ebss	# dest_end = _ebss
+    /* Clear .bss. It starts at _bss and ends at _ebss. */
+    la      t1_dest,     __bss
+    la      t2_dest_end, __ebss
 .Lclear_next_word:
-	/*     Everybody loves MIPS $zero register. */
-	sw	$zero, 0($t1)	# *dest = 0
-	addiu	$t1, 4		# dest++
-	bne	$t1, $t2, .Lclear_next_word
-	  nop			# jump if dest != dest_end
+    /* Everybody loves MIPS $zero register. */
+    sw      $zero, 0(t1_dest)
+    addiu   t1_dest, 4
+    bne     t1_dest, t2_dest_end, .Lclear_next_word
+     nop
 
-	/* Jump to kernel_main(). */
-	la $ra, kernel_main_exit # Set return address for kernel_main
+    /* Jump to kernel_main(). */
+    la      $ra, kernel_main_exit   // Set return address for kernel_main
     la      $t0, kernel_main
-    mtc0    $t0, C0_ERRPC # Store kernel_main address as exception return address to ErrorEPC
-	eret				  # Exception return.
+    mtc0    $t0, C0_ERRPC           // Store kernel_main address as exception return address to ErrorEPC
+    eret                            // Exception return.
 
 kernel_main_exit:
-	/* If for some reason kernel_main returned, loop forever. */
+    /* If for some reason kernel_main returned, loop forever. */
 .Lpost_exit_loop:
-	j	.Lpost_exit_loop
-	  nop
+    j   .Lpost_exit_loop
+     nop
 
 .end _start
 

--- a/startup.S
+++ b/startup.S
@@ -1,11 +1,8 @@
 #include <mips/m32c0.h>
-
-    .section .exception
-    .globl _start
-    .type _start, function
     .set noreorder      // Disable automatic instruction reordering.
 
-.org 0x000
+/* Exception vector. */
+.section .exception
 .ent __reset_vector
 __reset_vector:
     la  $a0, _start     // Jump to _start.
@@ -14,8 +11,10 @@ __reset_vector:
 .end __reset_vector
 
 
-/* Startup routine placed after exception vectors. */
-.org 0x500
+/* Startup routine. */
+.section .init
+.globl _start
+.type _start, function
 .ent _start
 _start:
     la  $sp, _estack    // Set stack pointer.

--- a/startup.s
+++ b/startup.s
@@ -1,43 +1,62 @@
 	.section .exception
 	.globl _start
 	.type _start, function
+	.set noreorder 	# Disable automatic instruction reordering.
 
-/* Boot code at 0xbfc00000 */
-_start:	la	$sp, _estack	# Set stack pointer.
+.org 0x000
+.ent __reset_vector
+__reset_vector:
+	la $a0, _start	# Jump to _start.
+	jr $a0
+	  nop
+.end __reset_vector
+
+
+/* Startup routine placed after exception vectors. */
+.org 0x500
+.ent _start
+_start:
+	la	$sp, _estack	# Set stack pointer.
 	la	$gp, _gp	# Prepare global pointer.
 
+copy_rom_to_ram:
 	/* Copy .data from ROM to RAM.
 	 * .data is located in ROM just after .text, so it starts at _etext.
 	 * It should land at the beggining of RAM, which is pointed at by _data.
 	 * Copy words one by one, until _edata is reached. */
-	la	$t1, _data	# dest = _data
-	la	$t2, _edata	# dest_end = _edata
-	la	$t3, _etext	# src = _etext
-copy_next_word:
+	la	$t1, __data	# dest = _data
+	la	$t2, __edata	# dest_end = _edata
+	la	$t3, __etext	# src = _etext
+.Lcopy_next_word:
 	lw	$t0, 0($t3)	# x = *src
 	sw	$t0, 0($t1)	# *dest = x
 	addiu	$t1, 4		# dest++
-	addiu	$t3, 4		# src++
-	bne	$t1, $t2, copy_next_word
-	  nop			# jump if dest != dest_end
+	bne	$t1, $t2, .Lcopy_next_word # jump if dest != dest_end
+	  addiu	$t3, 4		# src++
 
-	/*     Clean .bss. It starts at _bss and ends at _ebss. */
-	la	$t1, _bss	# dest = _bss
-	la	$t2, _ebss	# dest_end = _ebss
-clear_next_word:
+clear_bss:
+	/*     Clear .bss. It starts at _bss and ends at _ebss. */
+	la	$t1, __bss	# dest = _bss
+	la	$t2, __ebss	# dest_end = _ebss
+.Lclear_next_word:
 	/*     Everybody loves MIPS $zero register. */
 	sw	$zero, 0($t1)	# *dest = 0
 	addiu	$t1, 4		# dest++
-	bne	$t1, $t2, clear_next_word
+	bne	$t1, $t2, .Lclear_next_word
 	  nop			# jump if dest != dest_end
 
 	/* Jump to kernel_main(). */
-	jal	kernel_main
+	la $ra, kernel_main_exit # Set return address for kernel_main
+    la      $t0, kernel_main
+    mtc0    $t0, $30      # Store kernel_main address as exception return address to ErrorEPC
+	eret				  # Exception return.
 
+kernel_main_exit:
 	/* If for some reason kernel_main returned, loop forever. */
-loop:
-	j	loop
+.Lpost_exit_loop:
+	j	.Lpost_exit_loop
+	  nop
 
-	.text
+.end _start
 
 _estack = _end + 0x1000

--- a/startup.s
+++ b/startup.s
@@ -1,0 +1,43 @@
+	.section .exception
+	.globl _start
+	.type _start, function
+
+/* Boot code at 0xbfc00000 */
+_start:	la	$sp, _estack	# Set stack pointer.
+	la	$gp, _gp	# Prepare global pointer.
+
+	/* Copy .data from ROM to RAM.
+	 * .data is located in ROM just after .text, so it starts at _etext.
+	 * It should land at the beggining of RAM, which is pointed at by _data.
+	 * Copy words one by one, until _edata is reached. */
+	la	$t1, _data	# dest = _data
+	la	$t2, _edata	# dest_end = _edata
+	la	$t3, _etext	# src = _etext
+copy_next_word:
+	lw	$t0, 0($t3)	# x = *src
+	sw	$t0, 0($t1)	# *dest = x
+	addiu	$t1, 4		# dest++
+	addiu	$t3, 4		# src++
+	bne	$t1, $t2, copy_next_word
+	  nop			# jump if dest != dest_end
+
+	/*     Clean .bss. It starts at _bss and ends at _ebss. */
+	la	$t1, _bss	# dest = _bss
+	la	$t2, _ebss	# dest_end = _ebss
+clear_next_word:
+	/*     Everybody loves MIPS $zero register. */
+	sw	$zero, 0($t1)	# *dest = 0
+	addiu	$t1, 4		# dest++
+	bne	$t1, $t2, clear_next_word
+	  nop			# jump if dest != dest_end
+
+	/* Jump to kernel_main(). */
+	jal	kernel_main
+
+	/* If for some reason kernel_main returned, loop forever. */
+loop:
+	j	loop
+
+	.text
+
+_estack = _end + 0x1000


### PR DESCRIPTION
Moved `_start` to `startup.s`. The start procedure now copies `.data` to RAM, and clears `.bss`. Renamed `main()` to `kernel_main()`. 

Fixes #2.