### PR TITLE
Initial interrupt support, core timer interrupts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CPPFLAGS += -isystemsmallclib/include
 LDLIBS   = smallclib/smallclib.a
 
 PROGNAME = main
-SOURCES_C = main.c uart_raw.c interrupts.c
+SOURCES_C = main.c uart_raw.c interrupts.c clock.c
 SOURCES_ASM = startup.S intr.S
 OBJECTS_C := $(SOURCES_C:.c=.o)
 OBJECTS_ASM := $(SOURCES_ASM:.S=.o)

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ CPPFLAGS += -isystemsmallclib/include
 LDLIBS   = smallclib/smallclib.a
 
 PROGNAME = main
-SOURCES_C = main.c uart_raw.c
-SOURCES_ASM = startup.S
+SOURCES_C = main.c uart_raw.c interrupts.c
+SOURCES_ASM = startup.S intr.S
 OBJECTS_C := $(SOURCES_C:.c=.o)
 OBJECTS_ASM := $(SOURCES_ASM:.S=.o)
 OBJECTS = $(OBJECTS_C) $(OBJECTS_ASM)

--- a/clock.c
+++ b/clock.c
@@ -1,0 +1,61 @@
+#include "clock.h"
+#include "interrupts.h"
+#include "global_config.h"
+
+/* This counter is incremented every millisecond. */
+static volatile unsigned int timer_ms_count;
+
+void clock_init(){
+    /* Disable interrupts while we are configuring them. */
+    unsigned s = di();
+
+    /* Clear instruction counter. */
+    mtc0 (C0_COUNT, 0, 0);
+    /* Set compare register. */
+    mtc0 (C0_COMPARE, 0, TICKS_PER_MS);
+
+    /* Clear ms counter. */
+    timer_ms_count = 0;
+
+    /* Clear core timer interrupt status. */
+    IFSSET(0) = 1 << 0;
+    /* Set core timer interrupts priority to 6 (highest) */
+    unsigned p = IPC(0);
+    p &= ~PIC32_IPC_IP0(7); // Clear priority 0 bits
+    p |=  PIC32_IPC_IP0(6); // Set them to 6
+    IPC(0) = p;
+    /* Enable core timer interrupts. */
+    IECSET(0) = 1 << 0;
+
+    /* It is safe now to re-enable interrupts. */
+    ei(s);
+}
+
+unsigned clock_get_ms(){
+    return timer_ms_count;
+}
+
+
+void hardclock(){
+    unsigned compare = mfc0(C0_COMPARE, 0);
+    unsigned count   = mfc0(C0_COUNT, 0);
+    signed int diff = compare - count;
+    if (diff > 0){
+        /* Should not happen. Potentially spurious interrupt. */
+        return;
+    }
+
+    /* This loop is necessary, because sometimes we may miss some ticks. */
+    while (diff < TICKS_PER_MS){
+
+        compare += TICKS_PER_MS;
+
+        /* Increment the ms counter. This increment is atomic, because
+           entire _interrupt_handler disables nested interrupts. */
+        timer_ms_count += 1;
+
+        diff = compare - count;
+    }
+    /* Set compare register. */
+    mtc0(C0_COMPARE, 0, compare);
+}

--- a/clock.h
+++ b/clock.h
@@ -1,0 +1,13 @@
+#ifndef __CLOCK_H__
+#define __CLOCK_H__
+
+/* Initializes and enables core timer interrupts. */
+void clock_init();
+
+/* Returns the number of ms passed since timer started running. */
+unsigned clock_get_ms();
+
+/* Processes core timer interrupts. */
+void hardclock();
+
+#endif // __CLOCK_H__

--- a/global_config.h
+++ b/global_config.h
@@ -3,5 +3,6 @@
 
 #define MHZ     200             /* CPU clock. */
 
+#define TICKS_PER_MS (1000 * MHZ / 2)
 
 #endif // GLOBAL_CONFIG_H

--- a/interrupts.c
+++ b/interrupts.c
@@ -1,11 +1,9 @@
 #include "interrupts.h"
+#include "clock.h"
 #include <libkern.h>
 
 /* Provided by linker script. */
 extern const char __ebase[];
-
-/* This counter is incremented every millisecond. */
-static volatile unsigned int timer_ms_count;
 
 void intr_init(){
 
@@ -63,70 +61,13 @@ void intr_init(){
     mtc0(C0_STATUS, 0, status);
 }
 
-
-void intr_timer_init(){
-    /* Disable interrupts while we are configuring them. */
-    unsigned s = di();
-
-    /* Clear instruction counter. */
-    mtc0 (C0_COUNT, 0, 0);
-    /* Set compare register. */
-    mtc0 (C0_COMPARE, 0, TICKS_PER_MS);
-
-    /* Clear ms counter. */
-    timer_ms_count = 0;
-
-    /* Clear core timer interrupt status. */
-    IFSSET(0) = 1 << 0;
-    /* Set core timer interrupts priority to 6 (highest) */
-    unsigned p = IPC(0);
-    p &= ~PIC32_IPC_IP0(7); // Clear priority 0 bits
-    p |=  PIC32_IPC_IP0(6); // Set them to 6
-    IPC(0) = p;
-    /* Enable core timer interrupts. */
-    IECSET(0) = 1 << 0;
-
-    /* It is safe now to re-enable interrupts. */
-    ei(s);
-}
-
-unsigned intr_timer_get_ms(){
-    return timer_ms_count;
-}
-
-void intr_handler(){
+void intr_dispatcher(){
     unsigned irq_n = PIC32_INTSTAT_VEC(INTSTAT);
-    unsigned compare,count;
     /* Recognize interrupt type. */
     switch(irq_n){
     case PIC32_IRQ_CT:
         /* Core timer interrupt. */
-
-        /* Mark the interrupt as handled. */
-        //IFSCLR(0) = 1 << PIC32_IRQ_CT;
-
-        compare = mfc0(C0_COMPARE, 0);
-        count   = mfc0(C0_COUNT, 0);
-        signed int diff = compare - count;
-        if (diff > 0){
-            /* Should not happen. Potentially spurious interrupt. */
-            return;
-        }
-
-        /* This loop is necessary, because sometimes we may miss some ticks. */
-        while (diff < TICKS_PER_MS){
-
-            compare += TICKS_PER_MS;
-
-            /* Increment the ms counter. This increment is atomic, because
-               entire _interrupt_handler disables nested interrupts. */
-            timer_ms_count += 1;
-
-            diff = compare - count;
-        }
-        /* Set compare register. */
-        mtc0(C0_COMPARE, 0, compare);
-
+        hardclock();
         break;
     default:
         kprintf("Received unrecognized interrupt: %d!\n", irq_n);

--- a/interrupts.c
+++ b/interrupts.c
@@ -2,7 +2,7 @@
 #include <libkern.h>
 
 /* Provided by linker script. */
-extern char* __ebase;
+extern const char __ebase[];
 
 /* This counter is incremented every millisecond. */
 static volatile unsigned int timer_ms_count;

--- a/interrupts.c
+++ b/interrupts.c
@@ -1,0 +1,113 @@
+#include "interrupts.h"
+#include <libkern.h>
+
+/* Provided by linker script. */
+extern char* __ebase;
+
+/* This counter is incremented every millisecond. */
+static volatile unsigned int timer_ms_count;
+
+void init_interrupts(){
+
+    /* Changing EBase must be done with Status:BEV set to 1. */
+    unsigned status = mfc0(C0_STATUS, 0);
+    mtc0(C0_STATUS, 0, status | ST_BEV);
+
+    /* Set EBase. */
+    mtc0(C0_EBASE, 1, __ebase);
+
+    /* Restore Status, set BEV to 0. */
+    status &= ~ST_BEV;
+    mtc0(C0_STATUS, 0, status);
+
+    /* Set internal interrupt vector spacing to 32. This value will
+       not be used, because it is the External Interrupt Controller
+       that will calculate handler adresses. However, this value must
+       be non-zero in order to enable vectored interrupts. */
+    mtc0(C0_INTCTL, 1, 1 << 5);
+
+    /* Set EIC's vector spacing to 0. */
+    INTCON = 0;
+
+    /* Clear interrupt status. */
+    IFS(0) = 0;
+    IFS(1) = 0;
+    IFS(2) = 0;
+    IFS(3) = 0;
+    IFS(4) = 0;
+    IFS(5) = 0;
+
+    /* Enable interrupts. */
+    status |= ST_IE;
+    mtc0(C0_STATUS, 0, status);
+}
+
+
+void init_timer(){
+    /* Disable interrupts while we are configuring them. */
+    unsigned s = di();
+
+    /* Clear instruction counter. */
+    mtc0 (C0_COUNT, 0, 0);
+    /* Set compare register. */
+    mtc0 (C0_COMPARE, 0, TICKS_PER_MS);
+
+    /* Clear ms counter. */
+    timer_ms_count = 0;
+
+    /* Clear core timer interrupt status. */
+    IFSSET(0) = 1 << 0;
+    /* Set core timer interrupts priority to 6 (highest) */
+    unsigned p = IPC(0);
+    p &= ~PIC32_IPC_IP0(7); // Clear priority 0 bits
+    p |=  PIC32_IPC_IP0(6); // Set them to 6
+    IPC(0) = p;
+    /* Enable core timer interrupts. */
+    IECSET(0) = 1 << 0;
+
+    /* It is safe now to re-enable interrupts. */
+    ei(s);
+}
+
+unsigned timer_get_ms(){
+    return timer_ms_count;
+}
+
+void interrupt_handler(){
+    unsigned irq_n = PIC32_INTSTAT_VEC(INTSTAT);
+    unsigned compare,count;
+    /* Recognize interrupt type. */
+    switch(irq_n){
+    case PIC32_IRQ_CT:
+        /* Core timer interrupt. */
+
+        /* Mark the interrupt as handled. */
+        //IFSCLR(0) = 1 << PIC32_IRQ_CT;
+
+        compare = mfc0(C0_COMPARE, 0);
+        count   = mfc0(C0_COUNT, 0);
+        signed int diff = compare - count;
+        if (diff > 0){
+            /* Should not happen. Potentially spurious interrupt. */
+            return;
+        }
+
+        /* This loop is necessary, because sometimes we may miss some ticks. */
+        while (diff < TICKS_PER_MS){
+
+            compare += TICKS_PER_MS;
+
+            /* Increment the ms counter. This increment is atomic, because
+               entire _interrupt_handler disables nested interrupts. */
+            timer_ms_count += 1;
+
+            diff = compare - count;
+        }
+        /* Set compare register. */
+        mtc0(C0_COMPARE, 0, compare);
+
+        break;
+    default:
+        kprintf("Received unrecognized interrupt: %d!\n", irq_n);
+    }
+}

--- a/interrupts.c
+++ b/interrupts.c
@@ -9,7 +9,28 @@ static volatile unsigned int timer_ms_count;
 
 void init_interrupts(){
 
-    /* Changing EBase must be done with Status:BEV set to 1. */
+    /* PIC32 provides various interrupt modes it can be configured to
+     * use. Because of QEMU limits, the configuration we use is to
+     * enable External Interrupts Controller, and configure it to use
+     * vector spacing 0 (so there is a single interrupt handler).
+     */
+
+    /* The C0's EBase register stores the base address of interrupt
+     * handlers. In case of vectored interrupts, the actual handler
+     * address is calculated by the hadrware using formula:
+     *
+     *    EBase + vector_spacing * vector_no + 0x200.
+     *
+     * This way EBase might be used to quickly, globally switch to a
+     * different set of handlers.  Since we use vector_spacing = 0,
+     * the formula simplifies significantly.
+     */
+
+    /* For no clear reason, the architecture requires that changing
+     * EBase has to be done with Status:BEV set to 1. We will restore
+     * it to 0 afterwards, because BEV=1 enables Legacy (non-vectored)
+     * Interrupt Mode.
+     */
     unsigned status = mfc0(C0_STATUS, 0);
     mtc0(C0_STATUS, 0, status | ST_BEV);
 

--- a/interrupts.c
+++ b/interrupts.c
@@ -7,7 +7,7 @@ extern const char __ebase[];
 /* This counter is incremented every millisecond. */
 static volatile unsigned int timer_ms_count;
 
-void init_interrupts(){
+void intr_init(){
 
     /* PIC32 provides various interrupt modes it can be configured to
      * use. Because of QEMU limits, the configuration we use is to
@@ -64,7 +64,7 @@ void init_interrupts(){
 }
 
 
-void init_timer(){
+void intr_timer_init(){
     /* Disable interrupts while we are configuring them. */
     unsigned s = di();
 
@@ -90,11 +90,11 @@ void init_timer(){
     ei(s);
 }
 
-unsigned timer_get_ms(){
+unsigned intr_timer_get_ms(){
     return timer_ms_count;
 }
 
-void interrupt_handler(){
+void intr_handler(){
     unsigned irq_n = PIC32_INTSTAT_VEC(INTSTAT);
     unsigned compare,count;
     /* Recognize interrupt type. */

--- a/interrupts.h
+++ b/interrupts.h
@@ -1,0 +1,35 @@
+#ifndef __INTERRUPTS_H__
+#define __INTERRUPTS_H__
+
+#include "pic32mz.h"
+#include "global_config.h"
+
+/* Disables interrupts. Returns the previous value of Status
+   register. */
+#define di() ({                             \
+    int oldval;                             \
+    asm volatile ("di %0": "=r" (oldval));  \
+    oldval; })
+
+/* Re-enables interrupts previously disabled with di(). */
+#define ei(val) ({mtc0(C0_STATUS,0,(val));})
+
+/* Initializes and enables interrupts. */
+void init_interrupts();
+
+/* This is the single interrupt handler procedure. */
+void interrupt_handler();
+
+
+/* -- CORE TIMER -- */
+
+#define TICKS_PER_MS (1000 * MHZ / 2)
+
+/* Initializes and enables core timer interrupts. */
+void init_timer();
+
+/* Returns the number of ms passed since timer started running. */
+unsigned timer_get_ms();
+
+
+#endif

--- a/interrupts.h
+++ b/interrupts.h
@@ -23,8 +23,6 @@ void interrupt_handler();
 
 /* -- CORE TIMER -- */
 
-#define TICKS_PER_MS (1000 * MHZ / 2)
-
 /* Initializes and enables core timer interrupts. */
 void init_timer();
 

--- a/interrupts.h
+++ b/interrupts.h
@@ -2,7 +2,6 @@
 #define __INTERRUPTS_H__
 
 #include "pic32mz.h"
-#include "global_config.h"
 
 /* Disables interrupts. Returns the previous value of Status
    register. */
@@ -20,16 +19,6 @@ void intr_init();
 /* This is the single interrupt handler procedure. It should not be
  * called manually except by the interrupt handler routine from
  * intr.S.*/
-void intr_handler();
-
-
-/* -- CORE TIMER -- */
-
-/* Initializes and enables core timer interrupts. */
-void intr_timer_init();
-
-/* Returns the number of ms passed since timer started running. */
-unsigned intr_timer_get_ms();
-
+void intr_dispatcher();
 
 #endif

--- a/interrupts.h
+++ b/interrupts.h
@@ -15,19 +15,21 @@
 #define ei(val) ({mtc0(C0_STATUS,0,(val));})
 
 /* Initializes and enables interrupts. */
-void init_interrupts();
+void intr_init();
 
-/* This is the single interrupt handler procedure. */
-void interrupt_handler();
+/* This is the single interrupt handler procedure. It should not be
+ * called manually except by the interrupt handler routine from
+ * intr.S.*/
+void intr_handler();
 
 
 /* -- CORE TIMER -- */
 
 /* Initializes and enables core timer interrupts. */
-void init_timer();
+void intr_timer_init();
 
 /* Returns the number of ms passed since timer started running. */
-unsigned timer_get_ms();
+unsigned intr_timer_get_ms();
 
 
 #endif

--- a/intr.S
+++ b/intr.S
@@ -1,0 +1,91 @@
+    .set noreorder // Disable automatic instruction reordering
+
+    /* Interrupts vector */
+    .section .exception
+    .globl _interrupt_handler
+    .org 0x200
+_interrupt_handler:
+#define REG_STACK_STORE_SIZE 76
+    /* Please, no nested interrupts for now. */
+    di
+
+    /* Allocate space for register storage on the stack. */
+    subu $sp, $sp, REG_STACK_STORE_SIZE
+
+    /* Save registers on the stack. Saving all t,a and v
+       registers, as well as LO and HI.
+       k registers do not require saving.
+       s and sp registers are saved by compiler-generated
+       procedure entry, if the procedure modifies them.*/
+    sw $t0,  0 ($sp)
+    sw $t1,  4 ($sp)
+    sw $t2,  8 ($sp)
+    sw $t3, 12 ($sp)
+    sw $t4, 16 ($sp)
+    sw $t5, 20 ($sp)
+    sw $t6, 24 ($sp)
+    sw $t7, 28 ($sp)
+    sw $t8, 32 ($sp)
+    sw $t9, 36 ($sp)
+
+    /* Asking early, as these instructions require a few cycles. */
+    mflo $k0
+    mfhi $k1
+
+    sw $a0, 40 ($sp)
+    sw $a1, 44 ($sp)
+    sw $a2, 48 ($sp)
+    sw $a3, 52 ($sp)
+
+    sw $v0, 56 ($sp)
+    sw $v1, 60 ($sp)
+
+    /* Store LO/HI */
+    sw $k0, 64 ($sp)
+    sw $k1, 68 ($sp)
+
+    sw $ra, 72 ($sp)
+
+    /* Call the C routine. */
+    jal interrupt_handler
+     nop
+
+    /* Restore registers. */
+
+    lw $ra, 72 ($sp)
+
+    lw $k0, 64 ($sp)
+    lw $k1, 68 ($sp)
+    mtlo $k0
+    mthi $k1
+
+    lw $v0, 56 ($sp)
+    lw $v1, 60 ($sp)
+
+
+    lw $a0, 40 ($sp)
+    lw $a1, 44 ($sp)
+    lw $a2, 48 ($sp)
+    lw $a3, 52 ($sp)
+
+    lw $t0,  0 ($sp)
+    lw $t1,  4 ($sp)
+    lw $t2,  8 ($sp)
+    lw $t3, 12 ($sp)
+    lw $t4, 16 ($sp)
+    lw $t5, 20 ($sp)
+    lw $t6, 24 ($sp)
+    lw $t7, 28 ($sp)
+    lw $t8, 32 ($sp)
+    lw $t9, 36 ($sp)
+
+    /* Free stack. */
+    addu    $sp, $sp, REG_STACK_STORE_SIZE
+
+    /* Re-enable interrupts. */
+    ei
+    /* Exception return. */
+    eret
+.Lasd:
+    j .Lasd
+     nop

--- a/intr.S
+++ b/intr.S
@@ -2,9 +2,9 @@
 
     /* Interrupts vector */
     .section .exception
-    .globl _interrupt_handler
+    .globl _intr_handler
     .org 0x200
-_interrupt_handler:
+_intr_handler:
 #define REG_STACK_STORE_SIZE 76
     /* Please, no nested interrupts for now. */
     di
@@ -46,7 +46,7 @@ _interrupt_handler:
     sw $ra, 72 ($sp)
 
     /* Call the C routine. */
-    jal interrupt_handler
+    jal intr_handler
      nop
 
     /* Restore registers. */

--- a/intr.S
+++ b/intr.S
@@ -28,7 +28,6 @@ _interrupt_handler:
     sw $t8, 32 ($sp)
     sw $t9, 36 ($sp)
 
-    /* Asking early, as these instructions require a few cycles. */
     mflo $k0
     mfhi $k1
 

--- a/intr.S
+++ b/intr.S
@@ -46,7 +46,7 @@ _intr_handler:
     sw $ra, 72 ($sp)
 
     /* Call the C routine. */
-    jal intr_handler
+    jal intr_dispatcher
      nop
 
     /* Restore registers. */

--- a/main.c
+++ b/main.c
@@ -4,6 +4,7 @@
 #include "pic32mz.h"
 #include "uart_raw.h"
 #include "global_config.h"
+#include "interrupts.h"
 
 #include <libkern.h>
 
@@ -56,13 +57,20 @@ void udelay (unsigned usec)
     }
 }
 
+/*
+ * Delays for at least the given number of milliseconds.  May not be
+ * nanosecond-accurate.
+ */
+void mdelay (unsigned msec)
+{
+    unsigned now = timer_get_ms();
+    unsigned final = now + msec;
+    while(final > timer_get_ms());
+}
+
 int kernel_main()
 {
     /* Initialize coprocessor 0. */
-    mtc0 (C0_COUNT, 0, 0);
-    mtc0 (C0_COMPARE, 0, -1);
-    //mtc0 (C0_EBASE, 1, 0x9fc00000);     /* Vector base */
-    //mtc0 (C0_INTCTL, 1, 1 << 5);        /* Vector spacing 32 bytes */
     //mtc0 (C0_CAUSE, 0, 1 << 23);        /* Set IV */
     //mtc0 (C0_STATUS, 0, 0);             /* Clear BEV */
 
@@ -71,6 +79,8 @@ int kernel_main()
     TRISACLR = 0xCF;
     LATFCLR = 0x3000;
     TRISFCLR = 0x3000;
+
+    init_interrupts();
 
     /* Initialize UART. */
     uart_init();
@@ -118,18 +128,25 @@ int kernel_main()
     kprintf ("DEVCFG2  = 0x%08x\n", DEVCFG2    );
     kprintf ("DEVCFG3  = 0x%08x\n", DEVCFG3    );
 
+    init_timer();
+
+    unsigned last = 0;
     while (1) {
         /* Invert pins PA7-PA0. */
-        LATAINV = 1 << 0;  udelay (100000);
-        LATAINV = 1 << 1;  udelay (100000);
-        LATAINV = 1 << 2;  udelay (100000);
-        LATAINV = 1 << 3;  udelay (100000);
-        LATFINV = 1 << 13; udelay (100000);
-        LATFINV = 1 << 12; udelay (100000);
-        LATAINV = 1 << 6;  udelay (100000);
-        LATAINV = 1 << 7;  udelay (100000);
+        LATAINV = 1 << 0;  mdelay (100);
+        LATAINV = 1 << 1;  mdelay (100);
+        LATAINV = 1 << 2;  mdelay (100);
+        LATAINV = 1 << 3;  mdelay (100);
+        LATFINV = 1 << 13; mdelay (100);
+        LATFINV = 1 << 12; mdelay (100);
+        LATAINV = 1 << 6;  mdelay (100);
+        LATAINV = 1 << 7;  mdelay (100);
+
+        mdelay(200);
 
         loop++;
-        kprintf(".");
+        unsigned curr = timer_get_ms();
+        kprintf("Milliseconds since timer start: %d (diff: %d)\n", curr, curr - last);
+        last = curr;
     }
 }

--- a/main.c
+++ b/main.c
@@ -63,9 +63,9 @@ void udelay (unsigned usec)
  */
 void mdelay (unsigned msec)
 {
-    unsigned now = timer_get_ms();
+    unsigned now = intr_timer_get_ms();
     unsigned final = now + msec;
-    while(final > timer_get_ms());
+    while(final > intr_timer_get_ms());
 }
 
 int kernel_main()
@@ -80,7 +80,7 @@ int kernel_main()
     LATFCLR = 0x3000;
     TRISFCLR = 0x3000;
 
-    init_interrupts();
+    intr_init();
 
     /* Initialize UART. */
     uart_init();
@@ -128,7 +128,7 @@ int kernel_main()
     kprintf ("DEVCFG2  = 0x%08x\n", DEVCFG2    );
     kprintf ("DEVCFG3  = 0x%08x\n", DEVCFG3    );
 
-    init_timer();
+    intr_timer_init();
 
     unsigned last = 0;
     while (1) {
@@ -145,7 +145,7 @@ int kernel_main()
         mdelay(200);
 
         loop++;
-        unsigned curr = timer_get_ms();
+        unsigned curr = intr_timer_get_ms();
         kprintf("Milliseconds since timer start: %d (diff: %d)\n", curr, curr - last);
         last = curr;
     }

--- a/main.c
+++ b/main.c
@@ -5,6 +5,7 @@
 #include "uart_raw.h"
 #include "global_config.h"
 #include "interrupts.h"
+#include "clock.h"
 
 #include <libkern.h>
 
@@ -63,9 +64,9 @@ void udelay (unsigned usec)
  */
 void mdelay (unsigned msec)
 {
-    unsigned now = intr_timer_get_ms();
+    unsigned now = clock_get_ms();
     unsigned final = now + msec;
-    while(final > intr_timer_get_ms());
+    while(final > clock_get_ms());
 }
 
 int kernel_main()
@@ -128,7 +129,7 @@ int kernel_main()
     kprintf ("DEVCFG2  = 0x%08x\n", DEVCFG2    );
     kprintf ("DEVCFG3  = 0x%08x\n", DEVCFG3    );
 
-    intr_timer_init();
+    clock_init();
 
     unsigned last = 0;
     while (1) {
@@ -145,7 +146,7 @@ int kernel_main()
         mdelay(200);
 
         loop++;
-        unsigned curr = intr_timer_get_ms();
+        unsigned curr = clock_get_ms();
         kprintf("Milliseconds since timer start: %d (diff: %d)\n", curr, curr - last);
         last = curr;
     }

--- a/pic32mz.ld
+++ b/pic32mz.ld
@@ -21,6 +21,7 @@ SECTIONS
   {
     __text = ABSOLUTE(.);
     /* Exception handlers. */
+    __ebase = ABSOLUTE(.);
     *(.exception)
     . = 0x500;
     /* Execution starts here. */

--- a/startup.S
+++ b/startup.S
@@ -4,6 +4,7 @@
 /* Exception vector. */
 .section .exception
 .globl __reset_vector
+.org 0x0
 __reset_vector:
     la  $a0, _start     // Jump to _start.
     jr  $a0

--- a/startup.S
+++ b/startup.S
@@ -4,6 +4,14 @@
 /* Exception vector. */
 .section .exception
 .globl __reset_vector
+/* The .org 0x0 directive explicitly forces the routine to be placed
+ * exactly at the beginning of the .exception section. Not using this
+ * directive should yield the same result, but it is set explicitly in
+ * order to highlight the fact that offsets within .exception section
+ * shall not be arbitrary. This may save us from problems in case the
+ * assembler decided to place __reset_vector anywhere else but
+ * 0xbfc00000.
+ */
 .org 0x0
 __reset_vector:
     la  $a0, _start     // Jump to _start.


### PR DESCRIPTION
This branch introduces initial support for interrupt configuration and handling.

It uses a single interrupt handler (vector spacing = 0), as discussed per #8. The core timer is configured to emit a high-priority interrupt every millisecond. The handler stores register status on the stack, and then calls a C procedure, which recognizes interrupt type and processes it. In case of a core timer interrupt, it increments a millisecond counter. That counter is used to implement mdelay which blocks execution until that counter reaches desired value. kernel_main uses that function in the main loop, and reports the elapsed time (in ms) since it started.

In this implementation nested interrupts are unavailable. Should I enable them already?

[Note: This branch is a clone of `core_timer` with fixed commit history.]