### PR TITLE
A very basic physical memory manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CPPFLAGS += -isystemsmallclib/include
 LDLIBS   = smallclib/smallclib.a
 
 PROGNAME = main
-SOURCES_C = main.c uart_raw.c
+SOURCES_C = main.c uart_raw.c phys_mem.c
 SOURCES_ASM = startup.S
 OBJECTS_C := $(SOURCES_C:.c=.o)
 OBJECTS_ASM := $(SOURCES_ASM:.S=.o)

--- a/bitops.h
+++ b/bitops.h
@@ -1,0 +1,8 @@
+#ifndef __BITOPS_H__
+#define __BITOPS_H__
+
+#define   SET_BIT(n, b) (n |=  (1 << b) )
+#define CLEAR_BIT(n, b) (n &= ~(1 << b) )
+#define   GET_BIT(n, b) ((n & (1<<b)) != 0)
+
+#endif // __BITOPS_H__

--- a/bitops.h
+++ b/bitops.h
@@ -1,8 +1,10 @@
 #ifndef __BITOPS_H__
 #define __BITOPS_H__
 
-#define   SET_BIT(n, b) (n |=  (1 << b) )
-#define CLEAR_BIT(n, b) (n &= ~(1 << b) )
-#define   GET_BIT(n, b) ((n & (1<<b)) != 0)
+#define   SET_BIT(n, b) ((n) |=  (1 << (b)) )
+#define CLEAR_BIT(n, b) ((n) &= ~(1 << (b)) )
+#define   INV_BIT(n, b) ((n) ^=  (1 << (b)) )
+
+#define   GET_BIT(n, b) (((n) & (1<<(b))) != 0)
 
 #endif // __BITOPS_H__

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,9 @@
+This directory contains procedures that demonstrate some of kernel
+features. They are meant to serve as functionality proofs and
+examples, and therefore are a valuable documentation.
+
+When designing and/or implementing a new interface, you are welcome to
+drop an example usage in this directory.
+
+These files are not compiled by default, if you wish to run a
+demonstration, you need to compile and call it on your own.

--- a/demo/demo_pm.c
+++ b/demo/demo_pm.c
@@ -1,0 +1,44 @@
+#include "demos.h"
+#include "phys_mem.h"
+
+void demo_pm(){
+
+    pm_state_print();
+
+    kprintf("Allocating f1: %d frames. \n", 100000/FRAME_SIZE);
+    void* f1 = pm_frames_alloc(100000/FRAME_SIZE);
+    kprintf("f1 is at %x\n", f1);
+
+    pm_state_print();
+
+    kprintf("Allocating f2: %d frames. \n", 400000/FRAME_SIZE);
+    void* f2 = pm_frames_alloc(400000/FRAME_SIZE);
+    kprintf("f2 is at %x\n", f2);
+
+    pm_state_print();
+
+    // Prove we can access these addresses.
+    memset(f2,1,400000);
+
+    kprintf("Freeing f1\n");
+    pm_frames_free(f1,100000/FRAME_SIZE);
+
+    pm_state_print();
+
+    kprintf("Allocating f3: %d frames. \n", 50000/FRAME_SIZE);
+    // This region will only fit in the space that was freed by f1.
+    void* f3 = pm_frames_alloc(50000/FRAME_SIZE);
+    kprintf("f3 is at %x\n", f3);
+
+    pm_state_print();
+
+    kprintf("Freeing f2\n");
+    pm_frames_free(f2,400000/FRAME_SIZE);
+
+    pm_state_print();
+
+    kprintf("Freeing f3\n");
+    pm_frames_free(f3, 50000/FRAME_SIZE);
+
+    pm_state_print();
+}

--- a/demo/demos.h
+++ b/demo/demos.h
@@ -1,0 +1,10 @@
+#ifndef __DEMOS_H__
+#define __DEMOS_H__
+
+/* A trivial demonstration of physical memory manager features:
+ * Allocating a few different-sized batches of frames and freeing them
+ * aferwards, printing manager's internal state after each
+ * operation. */
+void demo_pm();
+
+#endif // __DEMOS_H__

--- a/main.c
+++ b/main.c
@@ -74,7 +74,7 @@ int kernel_main()
     TRISFCLR = 0x3000;
 
     /* Initialize physical memory management. */
-    init_phys_mem();
+    pm_init();
 
     /* Initialize UART. */
     uart_init();

--- a/main.c
+++ b/main.c
@@ -4,6 +4,7 @@
 #include "pic32mz.h"
 #include "uart_raw.h"
 #include "global_config.h"
+#include "phys_mem.h"
 
 #include <libkern.h>
 
@@ -71,6 +72,9 @@ int kernel_main()
     TRISACLR = 0xCF;
     LATFCLR = 0x3000;
     TRISFCLR = 0x3000;
+
+    /* Initialize physical memory management. */
+    init_phys_mem();
 
     /* Initialize UART. */
     uart_init();

--- a/phys_mem.c
+++ b/phys_mem.c
@@ -1,4 +1,5 @@
 #include "phys_mem.h"
+#include "bitops.h"
 #include <libkern.h>
 
 /* Provided by the linker. */
@@ -21,12 +22,6 @@ extern const char _end[];
 #define FRAME_BITMAP_TYPE unsigned
 static FRAME_BITMAP_TYPE frame_bitmap[FRAMES_N / sizeof(FRAME_BITMAP_TYPE) + 1];
 #define  FRAMES_PER_BITMAP_ENTRY (sizeof(FRAME_BITMAP_TYPE) * 8)
-
-/* These bit op macros are universally usefull. Shall we move them to
-   a common header? */
-#define   SET_BIT(n, b) (n |=  (1 << b) )
-#define CLEAR_BIT(n, b) (n &= ~(1 << b) )
-#define   GET_BIT(n, b) ((n & (1<<b)) != 0)
 
 /* Returns 1 iff nth frame is in use, 0 otherwise. */
 #define GET_FRAME_STATE(n) GET_BIT(frame_bitmap[n / FRAMES_PER_BITMAP_ENTRY], n % FRAMES_PER_BITMAP_ENTRY)

--- a/phys_mem.c
+++ b/phys_mem.c
@@ -1,0 +1,207 @@
+#include "phys_mem.h"
+#include <libkern.h>
+
+/* Provided by the linker. */
+extern const char _gp[];
+extern const char _end[];
+
+/* RAM bounds. */
+#define RAM_START _gp
+#define RAM_END  (_gp + RAM_SIZE)
+/* The RAM area that is used by kernel data (.data, .bss etc.) */
+#define KERNEL_RAM_START _gp
+#define KERNEL_RAM_END   _end
+
+/* The number of frames available in the entire RAM */
+#define FRAMES_N (RAM_SIZE/FRAME_SIZE)
+
+/* Each byte in the bitmap encodes the state of [word size]
+ * frames. The extra byte is added for the case when FRAME_N is not a
+ * multiply of [word size]. */
+#define FRAME_BITMAP_TYPE unsigned
+FRAME_BITMAP_TYPE frame_bitmap[FRAMES_N / sizeof(FRAME_BITMAP_TYPE) + 1];
+#define  FRAMES_PER_BITMAP_ENTRY (sizeof(FRAME_BITMAP_TYPE) * 8)
+
+/* These bit op macros are universally usefull. Shall we move them to
+   a common header? */
+#define   SET_BIT(n, b) (n |=  (1 << b) )
+#define CLEAR_BIT(n, b) (n &= ~(1 << b) )
+#define   GET_BIT(n, b) ((n & (1<<b)) != 0)
+
+/* Returns 1 iff nth frame is in use, 0 otherwise. */
+#define GET_FRAME_STATE(n) GET_BIT(frame_bitmap[n / FRAMES_PER_BITMAP_ENTRY], n % FRAMES_PER_BITMAP_ENTRY)
+
+/* Forward declaration. */
+void phys_mem_demo();
+
+/* Calculates to which frame a given address belongs, or returns -1 if
+   it is outside RAM. */
+size_t get_frame_no(const void* p){
+    const char* ptr = (const char*)p;
+    /* Test whether it is a valid physical RAM address. */
+    if(ptr < RAM_START || ptr > RAM_END){
+        kprintf("get_frame_no failed: Queried pointer %x is outside RAM bounds.", ptr);
+        return -1;
+    }
+    size_t offset = (char*)ptr - RAM_START;
+    size_t frame_no = offset / FRAME_SIZE;
+    return frame_no;
+}
+
+/* Translates a frame number into corresponding physical address. */
+void* get_frame_addr(size_t n){
+    return (char*)RAM_START + n*FRAME_SIZE;
+}
+
+/* This procedure marks all frames from first to last (inclusive) as
+ * used (if mark != 0) or unused (if mark == 0), but setting/clearing
+ * the corresponding bits of the frames bitmap. */
+void mark_frames_used(size_t first, size_t last, unsigned mark){
+    size_t frameno;
+    /* The following is not too efficient, for example, when setting
+       more than [word size] frames it would make sense to set an
+       entire byte at once. */
+    if(mark){
+        if(DEBUG_PHYS_MEM) kprintf("Marking frames %u to %u as used.\n", first, last);
+        for(frameno = first; frameno <= last; frameno++)
+            SET_BIT( frame_bitmap[frameno / FRAMES_PER_BITMAP_ENTRY],
+                     frameno % FRAMES_PER_BITMAP_ENTRY);
+    }else{
+        if(DEBUG_PHYS_MEM) kprintf("Marking frames %u to %u as unused.\n", first, last);
+        for(frameno = first; frameno <= last; frameno++)
+            CLEAR_BIT( frame_bitmap[frameno / FRAMES_PER_BITMAP_ENTRY],
+                       frameno % FRAMES_PER_BITMAP_ENTRY);
+    }
+}
+
+void init_phys_mem(){
+    size_t kernel_data_start_frame = get_frame_no(KERNEL_RAM_START);
+    size_t kernel_data_end_frame   = get_frame_no(KERNEL_RAM_END  );
+
+    if(DEBUG_PHYS_MEM) {
+        /* Some general info. */
+        kprintf("RAM size: %u, frame size: %u, frames no: %u, frames per bitmap entry: %u\n",
+                RAM_SIZE, FRAME_SIZE, FRAMES_N, FRAMES_PER_BITMAP_ENTRY);
+        kprintf("Kernel RAM data (.data, .sdata, .bss, .sbss) starts at %x and ends at %x.\n",
+                KERNEL_RAM_START, KERNEL_RAM_END);
+        kprintf("These addresses occupy frames from %u to %u\n",
+                kernel_data_start_frame, kernel_data_end_frame);
+    }
+
+    mark_frames_used(kernel_data_start_frame, kernel_data_end_frame, 1);
+
+    // Perform the demonstration.
+    if(DEBUG_PHYS_MEM) phys_mem_demo();
+}
+
+void phys_mem_print_state(){
+    kprintf("Physical memory manager internal state:\n");
+    /* Start from the last entry, and continue downwards. */
+    int i = FRAMES_N / FRAMES_PER_BITMAP_ENTRY - 1;
+    for(; i >= 0; i--){
+        const void* batch_start_addr = RAM_START +  i    * FRAME_SIZE    ;
+        const void* batch_end_addr   = RAM_START + (i+1) * FRAME_SIZE - 1;
+        kprintf("0x%08x - 0x%08x:  %08x\n", batch_end_addr, batch_start_addr, frame_bitmap[i]);
+    }
+}
+
+/* This function finds the frame at which a newly requested region
+   might begin. */
+size_t find_free_frames(size_t n){
+    if(DEBUG_PHYS_MEM) kprintf("Looking for %u free frames.\n", n);
+    /* A very simple first-fit implementation. */
+    /* A more efficient version would skip many frames at once, if
+     * they are all used. It would also probably keep a track of there
+     * a large free region begins, to find a fit more quickly. */
+    size_t current = 0;
+    size_t batch_start = 0;
+    size_t i = 0;
+    for(i = 0; i < FRAMES_N; i++){
+        if(GET_FRAME_STATE(i) == 0){
+            /* Empty frame */
+            current++;
+            if(current == n){
+                /* We found n free frames in a row! */
+                return batch_start;
+            }
+        }else{
+            /* Used frame */
+            current = 0;
+            batch_start = i+1;
+        }
+    }
+    /* Apparently, no fit was found. */
+    return -1;
+}
+
+void* alloc_frames(size_t n){
+    /* Find a fitting region. */
+    size_t where = find_free_frames(n);
+    if(where == (size_t)-1){
+        kprintf("Fatal error: Failed to allocate %d frames, no fit found.\n", n);
+        return NULL;
+    }
+    /* Mark the frames as used.*/
+    mark_frames_used(where, where + n - 1, 1);
+
+    return get_frame_addr(where);
+}
+
+void free_frames(const void* p, size_t n){
+    /* Check whether the pointer is frame-aligned. */
+    const char* ptr = (const char*)p;
+    if((ptr - RAM_START) % FRAME_SIZE != 0){
+        kprintf("Fatal error: Pointer passed to free_frames (%x) is not frame-aligned.\n", p);
+        // What to do now? We might use a panic() procedure.
+        return;
+    }
+    size_t where = get_frame_no(p);
+    /* Mark the frames as unused. */
+    mark_frames_used(where, where + n -1, 0);
+}
+
+/* ================================================ */
+
+
+/* A trivial demonstration. */
+void phys_mem_demo(){
+
+    phys_mem_print_state();
+
+    kprintf("Allocating f1: %d frames. \n", 100000/FRAME_SIZE);
+    void* f1 = alloc_frames(100000/FRAME_SIZE);
+    kprintf("f1 is at %x\n", f1);
+
+    phys_mem_print_state();
+
+    kprintf("Allocating f2: %d frames. \n", 400000/FRAME_SIZE);
+    void* f2 = alloc_frames(400000/FRAME_SIZE);
+    kprintf("f2 is at %x\n", f2);
+
+    phys_mem_print_state();
+
+    // Prove we can access these addresses.
+    memset(f2,1,400000);
+
+    kprintf("Freeing f1\n");
+    free_frames(f1,100000/FRAME_SIZE);
+
+    phys_mem_print_state();
+
+    kprintf("Allocating f3: %d frames. \n", 50000/FRAME_SIZE);
+    // This region will only fit in the space that was freed by f1.
+    void* f3 = alloc_frames(50000/FRAME_SIZE);
+    kprintf("f3 is at %x\n", f3);
+
+    phys_mem_print_state();
+
+    kprintf("Freeing f2\n");
+    free_frames(f2,400000/FRAME_SIZE);
+
+    phys_mem_print_state();
+
+    kprintf("Freeing f3\n");
+    free_frames(f3, 50000/FRAME_SIZE);
+
+    phys_mem_print_state();
+}

--- a/phys_mem.c
+++ b/phys_mem.c
@@ -26,9 +26,6 @@ static FRAME_BITMAP_TYPE frame_bitmap[FRAMES_N / sizeof(FRAME_BITMAP_TYPE) + 1];
 /* Returns 1 iff nth frame is in use, 0 otherwise. */
 #define GET_FRAME_STATE(n) GET_BIT(frame_bitmap[n / FRAMES_PER_BITMAP_ENTRY], n % FRAMES_PER_BITMAP_ENTRY)
 
-/* Forward declaration. */
-void demo_pm();
-
 /* Calculates to which frame a given address belongs, or returns -1 if
    it is outside RAM. */
 size_t pm_addr_to_frame_no(const void* p){
@@ -84,9 +81,6 @@ void pm_init(){
     }
 
     pm_frames_mark_used(kernel_data_start_frame, kernel_data_end_frame, 1);
-
-    // Perform the demonstration.
-    if(DEBUG_PHYS_MEM) demo_pm();
 }
 
 void pm_state_print(){
@@ -153,50 +147,4 @@ void pm_frames_free(const void* p, size_t n){
     size_t where = pm_addr_to_frame_no(p);
     /* Mark the frames as unused. */
     pm_frames_mark_used(where, where + n -1, 0);
-}
-
-/* ================================================ */
-
-
-/* A trivial demonstration. */
-void demo_pm(){
-
-    pm_state_print();
-
-    kprintf("Allocating f1: %d frames. \n", 100000/FRAME_SIZE);
-    void* f1 = pm_frames_alloc(100000/FRAME_SIZE);
-    kprintf("f1 is at %x\n", f1);
-
-    pm_state_print();
-
-    kprintf("Allocating f2: %d frames. \n", 400000/FRAME_SIZE);
-    void* f2 = pm_frames_alloc(400000/FRAME_SIZE);
-    kprintf("f2 is at %x\n", f2);
-
-    pm_state_print();
-
-    // Prove we can access these addresses.
-    memset(f2,1,400000);
-
-    kprintf("Freeing f1\n");
-    pm_frames_free(f1,100000/FRAME_SIZE);
-
-    pm_state_print();
-
-    kprintf("Allocating f3: %d frames. \n", 50000/FRAME_SIZE);
-    // This region will only fit in the space that was freed by f1.
-    void* f3 = pm_frames_alloc(50000/FRAME_SIZE);
-    kprintf("f3 is at %x\n", f3);
-
-    pm_state_print();
-
-    kprintf("Freeing f2\n");
-    pm_frames_free(f2,400000/FRAME_SIZE);
-
-    pm_state_print();
-
-    kprintf("Freeing f3\n");
-    pm_frames_free(f3, 50000/FRAME_SIZE);
-
-    pm_state_print();
 }

--- a/phys_mem.h
+++ b/phys_mem.h
@@ -1,0 +1,46 @@
+#ifndef __PHYS_MEM_H__
+#define __PHYS_MEM_H__
+#include <stddef.h>
+
+/* 1kiB frames. This value is a tunable. It would make sense to match
+ * frame size with virtual memory page size. */
+#define FRAME_SIZE 1024
+
+/* WiFire has 512kiB of RAM */
+#define RAM_SIZE 1024*512
+
+/* Set this to 1 if you need the physical memory manager to be
+ * verbose. */
+#define DEBUG_PHYS_MEM 0
+
+/* This function initializes the physical memory manager. It prepares
+ * the frame bitmap (taking the kernel data stored in ram into
+ * account) and optionally displays some debug info. It has to be
+ * called before any frame allocations. */
+void init_phys_mem();
+
+/* Allocates n physical frames. The allocated region is guaranteed to
+ * be continous, and will have exactly n * FRAME_SIZE bytes in
+ * size. Returns pointer to the start of the allocated reqion, or -1
+ * if allocation failed. */
+void* alloc_frames(size_t n) __attribute__((warn_unused_result));
+
+/* Frees frames which were prevoiusly allocated with
+ * alloc_frames(n). This will mark these frames as unused, making them
+ * available for future allocations. p has to be the pointer to the
+ * start of the allocated region, i.e. the pointer returned by the
+ * corresponding alloc_frames(n). If the pointer is not frame
+ * alligned, then it is clear it may not be a valid pointer returned
+ * by alloc_frames(n), and in such case this function will fail. Also,
+ * it is up to you to remember the number of frames allocated
+ * (i.e. the size of region you wish to free), normally this
+ * information gets stored somewhere within the allocated region. */
+void free_frames(const void* p, size_t n);
+
+/* Displays debug information concerning the internal state of the
+ * physical memory manager. Currently this displays the underlying
+ * frame bitmap in a readable format. Useful for testing the
+ * manager. */
+void phys_mem_print_state();
+
+#endif // __PHYS_MEM_H__

--- a/phys_mem.h
+++ b/phys_mem.h
@@ -11,7 +11,7 @@
 
 /* Set this to 1 if you need the physical memory manager to be
  * verbose. */
-#define DEBUG_PHYS_MEM 1
+#define DEBUG_PHYS_MEM 0
 
 /* This function initializes the physical memory manager. It prepares
  * the frame bitmap (taking the kernel data stored in ram into

--- a/phys_mem.h
+++ b/phys_mem.h
@@ -11,19 +11,19 @@
 
 /* Set this to 1 if you need the physical memory manager to be
  * verbose. */
-#define DEBUG_PHYS_MEM 0
+#define DEBUG_PHYS_MEM 1
 
 /* This function initializes the physical memory manager. It prepares
  * the frame bitmap (taking the kernel data stored in ram into
  * account) and optionally displays some debug info. It has to be
  * called before any frame allocations. */
-void init_phys_mem();
+void pm_init();
 
 /* Allocates n physical frames. The allocated region is guaranteed to
  * be continous, and will have exactly n * FRAME_SIZE bytes in
  * size. Returns pointer to the start of the allocated reqion, or -1
  * if allocation failed. */
-void* alloc_frames(size_t n) __attribute__((warn_unused_result));
+void* pm_frames_alloc(size_t n) __attribute__((warn_unused_result));
 
 /* Frees frames which were prevoiusly allocated with
  * alloc_frames(n). This will mark these frames as unused, making them
@@ -35,12 +35,12 @@ void* alloc_frames(size_t n) __attribute__((warn_unused_result));
  * it is up to you to remember the number of frames allocated
  * (i.e. the size of region you wish to free), normally this
  * information gets stored somewhere within the allocated region. */
-void free_frames(const void* p, size_t n);
+void pm_frames_free(const void* p, size_t n);
 
 /* Displays debug information concerning the internal state of the
  * physical memory manager. Currently this displays the underlying
  * frame bitmap in a readable format. Useful for testing the
  * manager. */
-void phys_mem_print_state();
+void pm_state_print();
 
 #endif // __PHYS_MEM_H__


### PR DESCRIPTION
Since we are going to need dynamic memory allocation pretty soon, I've started by implementing a simple physical memory manager. It uses a bitmap to track which frames are in use and which are free, and uses first-fit for finding free regions.

The manager is aware that the kernel stores some data in the memory (`.data`, `.bss`, etc.) and the frames containing it are marked as used during initialisation.

The algorithms used in this branch are not efficient. I believe substituting them with optimized variants should be considered a separate task.

The exposed interface boils down to:

```
void init_phys_mem();
void* alloc_frames(size_t n);
void free_frames(const void* p, size_t n);
```

Upon this basis an actual dynamic memory allocator could be implemented. We might also use some existing, fancy `malloc` implementation (smallclib provides one), as usually they only need the interface for getting and freeing n frames.

Toggling `DEBUG_PHYS_MEM` in `phys_mem.h` will cause a simple demonstration to be run during initialization.