### PR TITLE
Renamed _estack to _custom_estack.

### DIFF
--- a/pic32mz.ld
+++ b/pic32mz.ld
@@ -15,7 +15,7 @@ MEMORY
 SECTIONS
 {
   /* higher address of the user mode stack */
-  _estack = ORIGIN(ram) + LENGTH(ram);
+  _custom_estack = ORIGIN(ram) + LENGTH(ram);
 
   .text : AT(ORIGIN(flash))
   {

--- a/startup.S
+++ b/startup.S
@@ -25,7 +25,7 @@ __reset_vector:
 .type _start, function
 .ent _start
 _start:
-    la  $sp, _estack    // Set stack pointer.
+    la  $sp, _custom_estack // Set stack pointer.
     la  $gp, _gp        // Prepare global pointer.
 
 copy_rom_to_ram:


### PR DESCRIPTION
This is to work around linker preferring some another definition of `_estack` and ignoring ours (see #25).