### PR TITLE
Implemented early dynamic memory allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CPPFLAGS += -Iinclude
 LDLIBS   = smallclib/smallclib.a
 
 PROGNAME = main
-SOURCES_C = main.c uart_raw.c interrupts.c clock.c bitmap.c
+SOURCES_C = main.c uart_raw.c interrupts.c clock.c bitmap.c kmem.c
 SOURCES_ASM = startup.S intr.S init_gpr.S init_cp0.S init_caches.S init_tlb.S
 SOURCES = $(SOURCES_C) $(SOURCES_ASM)
 OBJECTS = $(SOURCES_C:.c=.o) $(SOURCES_ASM:.S=.o)

--- a/include/common.h
+++ b/include/common.h
@@ -1,19 +1,22 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
+
 #include <stdint.h>
+#include <stddef.h>
+
+/* Extra types. */
+
+typedef intptr_t word_t;
 
 /* Useful macros*/
-
 #define STR_NOEXPAND(x) #x     // This does not expand x.
 #define STR(x) STR_NOEXPAND(x) // This will expand x.
 
-
 /* Target platform properties. */
-
 #define BITS_IN_BYTE 8
+#define WORD_SIZE (sizeof(word_t) * BITS_IN_BYTE)
 
-typedef intptr_t word_t;
-#define WORD_SIZE (sizeof(word_t)*BITS_IN_BYTE)
-
+/* Aligns the address to given size (must be power of 2). */
+#define ALIGN(addr, size) (((uintptr_t)(addr) + (size) - 1) & ~((size) - 1))
 
 #endif // __COMMON_H__

--- a/include/kmem.h
+++ b/include/kmem.h
@@ -1,0 +1,26 @@
+#ifndef __KMEM_H__
+#define __KMEM_H__
+
+#include <common.h>
+
+/*
+ * This function provides simple dynamic memory allocation that may be used
+ * before any memory management has been initialised. This is useful, because
+ * sometimes it is needed to dynamically allocate memory for some data
+ * structures that are in use even before virtual memory management is ready.
+ * This function does it be pretending that the kernel's .bss section ends
+ * further than it originally did. In odred to allocate N bytes of memory, it
+ * pushes the pointer to the end of kernel's image by N bytes. This way such
+ * dynamically allocated structures are appended to the memory already occupied
+ * by kernel data. The extended end of kernel image is stored in
+ * km_kernel_bss_end, the physical memory manager will take it into account
+ * when started.
+ *
+ * The returned pointer is word-aligned. The block is filled with 0's.
+ */
+void* km_early_alloc(size_t size) __attribute__((warn_unused_result));
+
+/* Initializes km subsystem. */
+void km_init();
+
+#endif // __KMEM_H__

--- a/include/libkern.h
+++ b/include/libkern.h
@@ -11,6 +11,7 @@
 void *memset (void *m, int c, size_t n);
 void *memcpy (void *dst0, const void *src0, size_t len0);
 size_t strlen(const char *str);
+void bzero(void *s, size_t n);
 /* ============================================ */
 
 

--- a/kmem.c
+++ b/kmem.c
@@ -1,0 +1,19 @@
+#include "kmem.h"
+#include "libkern.h"
+#include "common.h"
+
+/* The end of the kernel's .bss section. Provided by the linker. */
+extern char __ebss[];
+
+/* This is the pointer to the extended end of kernel's image.
+ * It shall be always word-aligned. See km_early_alloc for details. */
+static uintptr_t km_kernel_image_end = (uintptr_t)__ebss;
+
+void* km_early_alloc(size_t size){
+    // TODO: Explicitly crash if this function is called after
+    // physical memory manager has been initialized.
+    void* ptr = (void*)km_kernel_image_end;
+    bzero(ptr, size);
+    km_kernel_image_end = ALIGN(km_kernel_image_end + size, sizeof(word_t));
+    return ptr;
+}

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 #include "global_config.h"
 #include "interrupts.h"
 #include "clock.h"
+#include "kmem.h"
 
 #include <libkern.h>
 

--- a/smallclib/Makefile
+++ b/smallclib/Makefile
@@ -24,6 +24,7 @@ LIB_SOURCES  = ctype/ctype_.c
 LIB_SOURCES += stdio/__format_parser_int.c
 LIB_SOURCES += string/memchr.c
 LIB_SOURCES += string/memset.c
+LIB_SOURCES += string/bzero.c
 LIB_SOURCES += string/memcpy.c
 LIB_SOURCES += string/strlen.c
 LIB_SOURCES += string/strspn.c


### PR DESCRIPTION
Implemented a bootstrap memory allocator as suggested in [this comment](https://github.com/cahirwpz/wifire-os/pull/17#issuecomment-168301900). The implementation is similar to [LiteBSD's](https://github.com/sergev/LiteBSD/blob/master/sys/mips/pic32/pmap.c#L181).

I was unsure to which namespace the allocator shall belong, so I ended up using `vm`.

Currently, allocating more than ~4000B will crash the kernel due to #25. However, the currently proposed fix for #25 solves the issue.