### PR TITLE
Uniform formatting for source files

### DIFF
--- a/astyle.options
+++ b/astyle.options
@@ -1,0 +1,30 @@
+# This file defines the options for astyle.
+# To run astyle with these options on all files, use:
+#     astyle --options=astyle.options --recursive "*.h" "*.c"
+# It will format all files in-place, saving a backup in .orig file.
+#
+# The documentation listing available options can be viewed at:
+#     http://astyle.sourceforge.net/astyle.html
+#
+# Various scripts, including emacs bindings are available here:
+#     http://astyle.sourceforge.net/scripts.html
+# However, configuring emacs to use k&r style and 4 spaces indent
+# should yield same result.
+
+mode=c
+style=k&r             # Kernigham and Ritchie's style
+indent=spaces=4       # Use spaces for indentation, 4 spaces per level
+max-code-length=80    # Split lines longer than 80 chars (if possible)
+convert-tabs          # Convert non-indentation tabs to spaces
+indent-labels         # Do not push switch labels to the far left
+keep-one-line-statements # Do not split up multiple statments placed
+                         # in a single line
+
+# Options for consideration - currently disabled:
+# pad-oper            # Add spaces around operators
+# pad-header          # Add a space after if/for/while/...
+# align-pointer=type  # void* ptr;
+# align-pointer=name  # void *ptr;
+# remove-brackets     # Remove brackets from single-statement blocks
+# indent-preproc-define  # Perform indentation inside preprocesor defines
+                         # It clearly has problems with elegant alignment.

--- a/bitmap.c
+++ b/bitmap.c
@@ -1,18 +1,20 @@
 #include "bitmap.h"
 #include "libkern.h"
 
-void __bitmap_printer_hex(word_t* bf, size_t size){
+void __bitmap_printer_hex(word_t* bf, size_t size)
+{
     int i;
     for(i = size - 1; i >= 0; i--)
         kprintf("%0" STR(BITS_IN_BYTE) "x", bf[i]);
 }
 
-void __bitmap_printer_bin(word_t* bf, size_t size){
+void __bitmap_printer_bin(word_t* bf, size_t size)
+{
     int i, bit;
-    for(i = size -1; i >= 0; i--){
+    for(i = size -1; i >= 0; i--) {
         word_t curr = bf[i];
         char bin[WORD_SIZE + 1];
-        for(bit = 0; bit < WORD_SIZE; bit++){
+        for(bit = 0; bit < WORD_SIZE; bit++) {
             bin[WORD_SIZE - bit - 1] = (curr & 0x1)?'1':'0';
             curr >>= 1;
         }

--- a/clock.c
+++ b/clock.c
@@ -5,7 +5,8 @@
 /* This counter is incremented every millisecond. */
 static volatile unsigned int timer_ms_count;
 
-void clock_init(){
+void clock_init()
+{
     /* Disable interrupts while we are configuring them. */
     unsigned s = di();
 
@@ -31,22 +32,24 @@ void clock_init(){
     ei(s);
 }
 
-unsigned clock_get_ms(){
+unsigned clock_get_ms()
+{
     return timer_ms_count;
 }
 
 
-void hardclock(){
+void hardclock()
+{
     unsigned compare = mfc0(C0_COMPARE, 0);
     unsigned count   = mfc0(C0_COUNT, 0);
     signed int diff = compare - count;
-    if (diff > 0){
+    if (diff > 0) {
         /* Should not happen. Potentially spurious interrupt. */
         return;
     }
 
     /* This loop is necessary, because sometimes we may miss some ticks. */
-    while (diff < TICKS_PER_MS){
+    while (diff < TICKS_PER_MS) {
 
         compare += TICKS_PER_MS;
 

--- a/include/pic32mz.h
+++ b/include/pic32mz.h
@@ -98,42 +98,42 @@
 /*
  * Status register.
  */
-#define ST_CU0		0x10000000	/* Access to coprocessor 0 allowed (in user mode) */
-#define ST_RP		0x08000000	/* Enable reduced power mode */
-#define ST_RE		0x02000000	/* Reverse endianness (in user mode) */
-#define ST_BEV		0x00400000	/* Exception vectors: bootstrap */
-#define ST_SR		0x00100000	/* Soft reset */
-#define ST_NMI		0x00080000	/* NMI reset */
-#define ST_IPL(x)	((x) << 10)	/* Current interrupt priority level */
-#define ST_UM		0x00000010	/* User mode */
-#define ST_ERL		0x00000004	/* Error level */
-#define ST_EXL		0x00000002	/* Exception level */
-#define ST_IE		0x00000001	/* Interrupt enable */
+#define ST_CU0      0x10000000  /* Access to coprocessor 0 allowed (in user mode) */
+#define ST_RP       0x08000000  /* Enable reduced power mode */
+#define ST_RE       0x02000000  /* Reverse endianness (in user mode) */
+#define ST_BEV      0x00400000  /* Exception vectors: bootstrap */
+#define ST_SR       0x00100000  /* Soft reset */
+#define ST_NMI      0x00080000  /* NMI reset */
+#define ST_IPL(x)   ((x) << 10) /* Current interrupt priority level */
+#define ST_UM       0x00000010  /* User mode */
+#define ST_ERL      0x00000004  /* Error level */
+#define ST_EXL      0x00000002  /* Exception level */
+#define ST_IE       0x00000001  /* Interrupt enable */
 
 /*
  * Сause register.
  */
-#define CA_BD		0x80000000	/* Exception occured in delay slot */
-#define CA_TI		0x40000000	/* Timer interrupt is pending */
-#define CA_CE		0x30000000	/* Coprocessor exception */
-#define CA_DC		0x08000000	/* Disable COUNT register */
-#define CA_IV		0x00800000	/* Use special interrupt vector 0x200 */
-#define CA_RIPL(r)	((r)>>10 & 63)	/* Requested interrupt priority level */
-#define CA_IP1		0x00020000	/* Request software interrupt 1 */
-#define CA_IP0		0x00010000	/* Request software interrupt 0 */
-#define CA_EXC_CODE	0x0000007c	/* Exception code */
+#define CA_BD       0x80000000  /* Exception occured in delay slot */
+#define CA_TI       0x40000000  /* Timer interrupt is pending */
+#define CA_CE       0x30000000  /* Coprocessor exception */
+#define CA_DC       0x08000000  /* Disable COUNT register */
+#define CA_IV       0x00800000  /* Use special interrupt vector 0x200 */
+#define CA_RIPL(r)  ((r)>>10 & 63)  /* Requested interrupt priority level */
+#define CA_IP1      0x00020000  /* Request software interrupt 1 */
+#define CA_IP0      0x00010000  /* Request software interrupt 0 */
+#define CA_EXC_CODE 0x0000007c  /* Exception code */
 
-#define CA_Int		0		/* Interrupt */
-#define CA_AdEL		(4 << 2)	/* Address error, load or instruction fetch */
-#define CA_AdES		(5 << 2)	/* Address error, store */
-#define CA_IBE		(6 << 2)	/* Bus error, instruction fetch */
-#define CA_DBE		(7 << 2)	/* Bus error, load or store */
-#define CA_Sys		(8 << 2)	/* Syscall */
-#define CA_Bp		(9 << 2)	/* Breakpoint */
-#define CA_RI		(10 << 2)	/* Reserved instruction */
-#define CA_CPU		(11 << 2)	/* Coprocessor unusable */
-#define CA_Ov		(12 << 2)	/* Arithmetic overflow */
-#define CA_Tr		(13 << 2)	/* Trap */
+#define CA_Int      0       /* Interrupt */
+#define CA_AdEL     (4 << 2)    /* Address error, load or instruction fetch */
+#define CA_AdES     (5 << 2)    /* Address error, store */
+#define CA_IBE      (6 << 2)    /* Bus error, instruction fetch */
+#define CA_DBE      (7 << 2)    /* Bus error, load or store */
+#define CA_Sys      (8 << 2)    /* Syscall */
+#define CA_Bp       (9 << 2)    /* Breakpoint */
+#define CA_RI       (10 << 2)   /* Reserved instruction */
+#define CA_CPU      (11 << 2)   /* Coprocessor unusable */
+#define CA_Ov       (12 << 2)   /* Arithmetic overflow */
+#define CA_Tr       (13 << 2)   /* Trap */
 
 #define DB_DBD          (1 << 31)       /* Debug exception in a branch delay slot */
 #define DB_DM           (1 << 30)       /* Debug mode */
@@ -159,26 +159,26 @@
 /*
  * Read C0 coprocessor register.
  */
-#define mfc0(reg, sel) ({ int __value;				\
-	asm volatile (						\
-	"mfc0	%0, $%1, %2"					\
-	: "=r" (__value) : "K" (reg), "K" (sel));		\
-	__value; })
+#define mfc0(reg, sel) ({ int __value;              \
+    asm volatile (                      \
+    "mfc0	%0, $%1, %2"                  \
+    : "=r" (__value) : "K" (reg), "K" (sel));       \
+    __value; })
 
 /*
  * Write coprocessor 0 register.
  */
 #define mtc0(reg, sel, value) asm volatile (                    \
-	"mtc0	%z0, $%1, %2"                                   \
-	: : "r" ((unsigned) (value)), "K" (reg), "K" (sel))
+    "mtc0	%z0, $%1, %2"                                   \
+    : : "r" ((unsigned) (value)), "K" (reg), "K" (sel))
 
 /*--------------------------------------
  * Configuration registers.
  */
-#define DEVCFG0		*(volatile unsigned*) 0xbfc0ffcc
-#define DEVCFG1		*(volatile unsigned*) 0xbfc0ffc8
-#define DEVCFG2		*(volatile unsigned*) 0xbfc0ffc4
-#define DEVCFG3		*(volatile unsigned*) 0xbfc0ffc0
+#define DEVCFG0     *(volatile unsigned*) 0xbfc0ffcc
+#define DEVCFG1     *(volatile unsigned*) 0xbfc0ffc8
+#define DEVCFG2     *(volatile unsigned*) 0xbfc0ffc4
+#define DEVCFG3     *(volatile unsigned*) 0xbfc0ffc0
 
 #define PIC32_DEVCFG(cfg0, cfg1, cfg2, cfg3) \
     unsigned __DEVCFG0 __attribute__ ((section (".config0"))) = (cfg0) ^ 0x7fffffff; \
@@ -313,668 +313,668 @@
 /*--------------------------------------
  * Peripheral registers.
  */
-#define PIC32_R(a)		*(volatile unsigned*) (0xBF800000 + (a))
+#define PIC32_R(a)      *(volatile unsigned*) (0xBF800000 + (a))
 
 /*--------------------------------------
  * Port A-K registers.
  */
-#define ANSELA		PIC32_R (0x60000) /* Port A: analog select */
-#define ANSELACLR	PIC32_R (0x60004)
-#define ANSELASET	PIC32_R (0x60008)
-#define ANSELAINV	PIC32_R (0x6000C)
-#define TRISA		PIC32_R (0x60010) /* Port A: mask of inputs */
-#define TRISACLR	PIC32_R (0x60014)
-#define TRISASET	PIC32_R (0x60018)
-#define TRISAINV	PIC32_R (0x6001C)
-#define PORTA		PIC32_R (0x60020) /* Port A: read inputs, write outputs */
-#define PORTACLR	PIC32_R (0x60024)
-#define PORTASET	PIC32_R (0x60028)
-#define PORTAINV	PIC32_R (0x6002C)
-#define LATA		PIC32_R (0x60030) /* Port A: read/write outputs */
-#define LATACLR		PIC32_R (0x60034)
-#define LATASET		PIC32_R (0x60038)
-#define LATAINV		PIC32_R (0x6003C)
-#define ODCA		PIC32_R (0x60040) /* Port A: open drain configuration */
-#define ODCACLR		PIC32_R (0x60044)
-#define ODCASET		PIC32_R (0x60048)
-#define ODCAINV		PIC32_R (0x6004C)
-#define CNPUA		PIC32_R (0x60050) /* Port A: input pin pull-up enable */
-#define CNPUACLR	PIC32_R (0x60054)
-#define CNPUASET	PIC32_R (0x60058)
-#define CNPUAINV	PIC32_R (0x6005C)
-#define CNPDA		PIC32_R (0x60060) /* Port A: input pin pull-down enable */
-#define CNPDACLR	PIC32_R (0x60064)
-#define CNPDASET	PIC32_R (0x60068)
-#define CNPDAINV	PIC32_R (0x6006C)
-#define CNCONA		PIC32_R (0x60070) /* Port A: interrupt-on-change control */
-#define CNCONACLR	PIC32_R (0x60074)
-#define CNCONASET	PIC32_R (0x60078)
-#define CNCONAINV	PIC32_R (0x6007C)
-#define CNENA		PIC32_R (0x60080) /* Port A: input change interrupt enable */
-#define CNENACLR	PIC32_R (0x60084)
-#define CNENASET	PIC32_R (0x60088)
-#define CNENAINV	PIC32_R (0x6008C)
-#define CNSTATA		PIC32_R (0x60090) /* Port A: status */
-#define CNSTATACLR	PIC32_R (0x60094)
-#define CNSTATASET	PIC32_R (0x60098)
-#define CNSTATAINV	PIC32_R (0x6009C)
+#define ANSELA      PIC32_R (0x60000) /* Port A: analog select */
+#define ANSELACLR   PIC32_R (0x60004)
+#define ANSELASET   PIC32_R (0x60008)
+#define ANSELAINV   PIC32_R (0x6000C)
+#define TRISA       PIC32_R (0x60010) /* Port A: mask of inputs */
+#define TRISACLR    PIC32_R (0x60014)
+#define TRISASET    PIC32_R (0x60018)
+#define TRISAINV    PIC32_R (0x6001C)
+#define PORTA       PIC32_R (0x60020) /* Port A: read inputs, write outputs */
+#define PORTACLR    PIC32_R (0x60024)
+#define PORTASET    PIC32_R (0x60028)
+#define PORTAINV    PIC32_R (0x6002C)
+#define LATA        PIC32_R (0x60030) /* Port A: read/write outputs */
+#define LATACLR     PIC32_R (0x60034)
+#define LATASET     PIC32_R (0x60038)
+#define LATAINV     PIC32_R (0x6003C)
+#define ODCA        PIC32_R (0x60040) /* Port A: open drain configuration */
+#define ODCACLR     PIC32_R (0x60044)
+#define ODCASET     PIC32_R (0x60048)
+#define ODCAINV     PIC32_R (0x6004C)
+#define CNPUA       PIC32_R (0x60050) /* Port A: input pin pull-up enable */
+#define CNPUACLR    PIC32_R (0x60054)
+#define CNPUASET    PIC32_R (0x60058)
+#define CNPUAINV    PIC32_R (0x6005C)
+#define CNPDA       PIC32_R (0x60060) /* Port A: input pin pull-down enable */
+#define CNPDACLR    PIC32_R (0x60064)
+#define CNPDASET    PIC32_R (0x60068)
+#define CNPDAINV    PIC32_R (0x6006C)
+#define CNCONA      PIC32_R (0x60070) /* Port A: interrupt-on-change control */
+#define CNCONACLR   PIC32_R (0x60074)
+#define CNCONASET   PIC32_R (0x60078)
+#define CNCONAINV   PIC32_R (0x6007C)
+#define CNENA       PIC32_R (0x60080) /* Port A: input change interrupt enable */
+#define CNENACLR    PIC32_R (0x60084)
+#define CNENASET    PIC32_R (0x60088)
+#define CNENAINV    PIC32_R (0x6008C)
+#define CNSTATA     PIC32_R (0x60090) /* Port A: status */
+#define CNSTATACLR  PIC32_R (0x60094)
+#define CNSTATASET  PIC32_R (0x60098)
+#define CNSTATAINV  PIC32_R (0x6009C)
 
-#define ANSELB		PIC32_R (0x60100) /* Port B: analog select */
-#define ANSELBCLR	PIC32_R (0x60104)
-#define ANSELBSET	PIC32_R (0x60108)
-#define ANSELBINV	PIC32_R (0x6010C)
-#define TRISB		PIC32_R (0x60110) /* Port B: mask of inputs */
-#define TRISBCLR	PIC32_R (0x60114)
-#define TRISBSET	PIC32_R (0x60118)
-#define TRISBINV	PIC32_R (0x6011C)
-#define PORTB		PIC32_R (0x60120) /* Port B: read inputs, write outputs */
-#define PORTBCLR	PIC32_R (0x60124)
-#define PORTBSET	PIC32_R (0x60128)
-#define PORTBINV	PIC32_R (0x6012C)
-#define LATB		PIC32_R (0x60130) /* Port B: read/write outputs */
-#define LATBCLR		PIC32_R (0x60134)
-#define LATBSET		PIC32_R (0x60138)
-#define LATBINV		PIC32_R (0x6013C)
-#define ODCB		PIC32_R (0x60140) /* Port B: open drain configuration */
-#define ODCBCLR		PIC32_R (0x60144)
-#define ODCBSET		PIC32_R (0x60148)
-#define ODCBINV		PIC32_R (0x6014C)
-#define CNPUB		PIC32_R (0x60150) /* Port B: input pin pull-up enable */
-#define CNPUBCLR	PIC32_R (0x60154)
-#define CNPUBSET	PIC32_R (0x60158)
-#define CNPUBINV	PIC32_R (0x6015C)
-#define CNPDB		PIC32_R (0x60160) /* Port B: input pin pull-down enable */
-#define CNPDBCLR	PIC32_R (0x60164)
-#define CNPDBSET	PIC32_R (0x60168)
-#define CNPDBINV	PIC32_R (0x6016C)
-#define CNCONB		PIC32_R (0x60170) /* Port B: interrupt-on-change control */
-#define CNCONBCLR	PIC32_R (0x60174)
-#define CNCONBSET	PIC32_R (0x60178)
-#define CNCONBINV	PIC32_R (0x6017C)
-#define CNENB		PIC32_R (0x60180) /* Port B: input change interrupt enable */
-#define CNENBCLR	PIC32_R (0x60184)
-#define CNENBSET	PIC32_R (0x60188)
-#define CNENBINV	PIC32_R (0x6018C)
-#define CNSTATB		PIC32_R (0x60190) /* Port B: status */
-#define CNSTATBCLR	PIC32_R (0x60194)
-#define CNSTATBSET	PIC32_R (0x60198)
-#define CNSTATBINV	PIC32_R (0x6019C)
+#define ANSELB      PIC32_R (0x60100) /* Port B: analog select */
+#define ANSELBCLR   PIC32_R (0x60104)
+#define ANSELBSET   PIC32_R (0x60108)
+#define ANSELBINV   PIC32_R (0x6010C)
+#define TRISB       PIC32_R (0x60110) /* Port B: mask of inputs */
+#define TRISBCLR    PIC32_R (0x60114)
+#define TRISBSET    PIC32_R (0x60118)
+#define TRISBINV    PIC32_R (0x6011C)
+#define PORTB       PIC32_R (0x60120) /* Port B: read inputs, write outputs */
+#define PORTBCLR    PIC32_R (0x60124)
+#define PORTBSET    PIC32_R (0x60128)
+#define PORTBINV    PIC32_R (0x6012C)
+#define LATB        PIC32_R (0x60130) /* Port B: read/write outputs */
+#define LATBCLR     PIC32_R (0x60134)
+#define LATBSET     PIC32_R (0x60138)
+#define LATBINV     PIC32_R (0x6013C)
+#define ODCB        PIC32_R (0x60140) /* Port B: open drain configuration */
+#define ODCBCLR     PIC32_R (0x60144)
+#define ODCBSET     PIC32_R (0x60148)
+#define ODCBINV     PIC32_R (0x6014C)
+#define CNPUB       PIC32_R (0x60150) /* Port B: input pin pull-up enable */
+#define CNPUBCLR    PIC32_R (0x60154)
+#define CNPUBSET    PIC32_R (0x60158)
+#define CNPUBINV    PIC32_R (0x6015C)
+#define CNPDB       PIC32_R (0x60160) /* Port B: input pin pull-down enable */
+#define CNPDBCLR    PIC32_R (0x60164)
+#define CNPDBSET    PIC32_R (0x60168)
+#define CNPDBINV    PIC32_R (0x6016C)
+#define CNCONB      PIC32_R (0x60170) /* Port B: interrupt-on-change control */
+#define CNCONBCLR   PIC32_R (0x60174)
+#define CNCONBSET   PIC32_R (0x60178)
+#define CNCONBINV   PIC32_R (0x6017C)
+#define CNENB       PIC32_R (0x60180) /* Port B: input change interrupt enable */
+#define CNENBCLR    PIC32_R (0x60184)
+#define CNENBSET    PIC32_R (0x60188)
+#define CNENBINV    PIC32_R (0x6018C)
+#define CNSTATB     PIC32_R (0x60190) /* Port B: status */
+#define CNSTATBCLR  PIC32_R (0x60194)
+#define CNSTATBSET  PIC32_R (0x60198)
+#define CNSTATBINV  PIC32_R (0x6019C)
 
-#define ANSELC		PIC32_R (0x60200) /* Port C: analog select */
-#define ANSELCCLR	PIC32_R (0x60204)
-#define ANSELCSET	PIC32_R (0x60208)
-#define ANSELCINV	PIC32_R (0x6020C)
-#define TRISC		PIC32_R (0x60210) /* Port C: mask of inputs */
-#define TRISCCLR	PIC32_R (0x60214)
-#define TRISCSET	PIC32_R (0x60218)
-#define TRISCINV	PIC32_R (0x6021C)
-#define PORTC		PIC32_R (0x60220) /* Port C: read inputs, write outputs */
-#define PORTCCLR	PIC32_R (0x60224)
-#define PORTCSET	PIC32_R (0x60228)
-#define PORTCINV	PIC32_R (0x6022C)
-#define LATC		PIC32_R (0x60230) /* Port C: read/write outputs */
-#define LATCCLR		PIC32_R (0x60234)
-#define LATCSET		PIC32_R (0x60238)
-#define LATCINV		PIC32_R (0x6023C)
-#define ODCC		PIC32_R (0x60240) /* Port C: open drain configuration */
-#define ODCCCLR		PIC32_R (0x60244)
-#define ODCCSET		PIC32_R (0x60248)
-#define ODCCINV		PIC32_R (0x6024C)
-#define CNPUC		PIC32_R (0x60250) /* Port C: input pin pull-up enable */
-#define CNPUCCLR	PIC32_R (0x60254)
-#define CNPUCSET	PIC32_R (0x60258)
-#define CNPUCINV	PIC32_R (0x6025C)
-#define CNPDC		PIC32_R (0x60260) /* Port C: input pin pull-down enable */
-#define CNPDCCLR	PIC32_R (0x60264)
-#define CNPDCSET	PIC32_R (0x60268)
-#define CNPDCINV	PIC32_R (0x6026C)
-#define CNCONC		PIC32_R (0x60270) /* Port C: interrupt-on-change control */
-#define CNCONCCLR	PIC32_R (0x60274)
-#define CNCONCSET	PIC32_R (0x60278)
-#define CNCONCINV	PIC32_R (0x6027C)
-#define CNENC		PIC32_R (0x60280) /* Port C: input change interrupt enable */
-#define CNENCCLR	PIC32_R (0x60284)
-#define CNENCSET	PIC32_R (0x60288)
-#define CNENCINV	PIC32_R (0x6028C)
-#define CNSTATC		PIC32_R (0x60290) /* Port C: status */
-#define CNSTATCCLR	PIC32_R (0x60294)
-#define CNSTATCSET	PIC32_R (0x60298)
-#define CNSTATCINV	PIC32_R (0x6029C)
+#define ANSELC      PIC32_R (0x60200) /* Port C: analog select */
+#define ANSELCCLR   PIC32_R (0x60204)
+#define ANSELCSET   PIC32_R (0x60208)
+#define ANSELCINV   PIC32_R (0x6020C)
+#define TRISC       PIC32_R (0x60210) /* Port C: mask of inputs */
+#define TRISCCLR    PIC32_R (0x60214)
+#define TRISCSET    PIC32_R (0x60218)
+#define TRISCINV    PIC32_R (0x6021C)
+#define PORTC       PIC32_R (0x60220) /* Port C: read inputs, write outputs */
+#define PORTCCLR    PIC32_R (0x60224)
+#define PORTCSET    PIC32_R (0x60228)
+#define PORTCINV    PIC32_R (0x6022C)
+#define LATC        PIC32_R (0x60230) /* Port C: read/write outputs */
+#define LATCCLR     PIC32_R (0x60234)
+#define LATCSET     PIC32_R (0x60238)
+#define LATCINV     PIC32_R (0x6023C)
+#define ODCC        PIC32_R (0x60240) /* Port C: open drain configuration */
+#define ODCCCLR     PIC32_R (0x60244)
+#define ODCCSET     PIC32_R (0x60248)
+#define ODCCINV     PIC32_R (0x6024C)
+#define CNPUC       PIC32_R (0x60250) /* Port C: input pin pull-up enable */
+#define CNPUCCLR    PIC32_R (0x60254)
+#define CNPUCSET    PIC32_R (0x60258)
+#define CNPUCINV    PIC32_R (0x6025C)
+#define CNPDC       PIC32_R (0x60260) /* Port C: input pin pull-down enable */
+#define CNPDCCLR    PIC32_R (0x60264)
+#define CNPDCSET    PIC32_R (0x60268)
+#define CNPDCINV    PIC32_R (0x6026C)
+#define CNCONC      PIC32_R (0x60270) /* Port C: interrupt-on-change control */
+#define CNCONCCLR   PIC32_R (0x60274)
+#define CNCONCSET   PIC32_R (0x60278)
+#define CNCONCINV   PIC32_R (0x6027C)
+#define CNENC       PIC32_R (0x60280) /* Port C: input change interrupt enable */
+#define CNENCCLR    PIC32_R (0x60284)
+#define CNENCSET    PIC32_R (0x60288)
+#define CNENCINV    PIC32_R (0x6028C)
+#define CNSTATC     PIC32_R (0x60290) /* Port C: status */
+#define CNSTATCCLR  PIC32_R (0x60294)
+#define CNSTATCSET  PIC32_R (0x60298)
+#define CNSTATCINV  PIC32_R (0x6029C)
 
-#define ANSELD		PIC32_R (0x60300) /* Port D: analog select */
-#define ANSELDCLR	PIC32_R (0x60304)
-#define ANSELDSET	PIC32_R (0x60308)
-#define ANSELDINV	PIC32_R (0x6030C)
-#define TRISD		PIC32_R (0x60310) /* Port D: mask of inputs */
-#define TRISDCLR	PIC32_R (0x60314)
-#define TRISDSET	PIC32_R (0x60318)
-#define TRISDINV	PIC32_R (0x6031C)
-#define PORTD		PIC32_R (0x60320) /* Port D: read inputs, write outputs */
-#define PORTDCLR	PIC32_R (0x60324)
-#define PORTDSET	PIC32_R (0x60328)
-#define PORTDINV	PIC32_R (0x6032C)
-#define LATD		PIC32_R (0x60330) /* Port D: read/write outputs */
-#define LATDCLR		PIC32_R (0x60334)
-#define LATDSET		PIC32_R (0x60338)
-#define LATDINV		PIC32_R (0x6033C)
-#define ODCD		PIC32_R (0x60340) /* Port D: open drain configuration */
-#define ODCDCLR		PIC32_R (0x60344)
-#define ODCDSET		PIC32_R (0x60348)
-#define ODCDINV		PIC32_R (0x6034C)
-#define CNPUD		PIC32_R (0x60350) /* Port D: input pin pull-up enable */
-#define CNPUDCLR	PIC32_R (0x60354)
-#define CNPUDSET	PIC32_R (0x60358)
-#define CNPUDINV	PIC32_R (0x6035C)
-#define CNPDD		PIC32_R (0x60360) /* Port D: input pin pull-down enable */
-#define CNPDDCLR	PIC32_R (0x60364)
-#define CNPDDSET	PIC32_R (0x60368)
-#define CNPDDINV	PIC32_R (0x6036C)
-#define CNCOND		PIC32_R (0x60370) /* Port D: interrupt-on-change control */
-#define CNCONDCLR	PIC32_R (0x60374)
-#define CNCONDSET	PIC32_R (0x60378)
-#define CNCONDINV	PIC32_R (0x6037C)
-#define CNEND		PIC32_R (0x60380) /* Port D: input change interrupt enable */
-#define CNENDCLR	PIC32_R (0x60384)
-#define CNENDSET	PIC32_R (0x60388)
-#define CNENDINV	PIC32_R (0x6038C)
-#define CNSTATD		PIC32_R (0x60390) /* Port D: status */
-#define CNSTATDCLR	PIC32_R (0x60394)
-#define CNSTATDSET	PIC32_R (0x60398)
-#define CNSTATDINV	PIC32_R (0x6039C)
+#define ANSELD      PIC32_R (0x60300) /* Port D: analog select */
+#define ANSELDCLR   PIC32_R (0x60304)
+#define ANSELDSET   PIC32_R (0x60308)
+#define ANSELDINV   PIC32_R (0x6030C)
+#define TRISD       PIC32_R (0x60310) /* Port D: mask of inputs */
+#define TRISDCLR    PIC32_R (0x60314)
+#define TRISDSET    PIC32_R (0x60318)
+#define TRISDINV    PIC32_R (0x6031C)
+#define PORTD       PIC32_R (0x60320) /* Port D: read inputs, write outputs */
+#define PORTDCLR    PIC32_R (0x60324)
+#define PORTDSET    PIC32_R (0x60328)
+#define PORTDINV    PIC32_R (0x6032C)
+#define LATD        PIC32_R (0x60330) /* Port D: read/write outputs */
+#define LATDCLR     PIC32_R (0x60334)
+#define LATDSET     PIC32_R (0x60338)
+#define LATDINV     PIC32_R (0x6033C)
+#define ODCD        PIC32_R (0x60340) /* Port D: open drain configuration */
+#define ODCDCLR     PIC32_R (0x60344)
+#define ODCDSET     PIC32_R (0x60348)
+#define ODCDINV     PIC32_R (0x6034C)
+#define CNPUD       PIC32_R (0x60350) /* Port D: input pin pull-up enable */
+#define CNPUDCLR    PIC32_R (0x60354)
+#define CNPUDSET    PIC32_R (0x60358)
+#define CNPUDINV    PIC32_R (0x6035C)
+#define CNPDD       PIC32_R (0x60360) /* Port D: input pin pull-down enable */
+#define CNPDDCLR    PIC32_R (0x60364)
+#define CNPDDSET    PIC32_R (0x60368)
+#define CNPDDINV    PIC32_R (0x6036C)
+#define CNCOND      PIC32_R (0x60370) /* Port D: interrupt-on-change control */
+#define CNCONDCLR   PIC32_R (0x60374)
+#define CNCONDSET   PIC32_R (0x60378)
+#define CNCONDINV   PIC32_R (0x6037C)
+#define CNEND       PIC32_R (0x60380) /* Port D: input change interrupt enable */
+#define CNENDCLR    PIC32_R (0x60384)
+#define CNENDSET    PIC32_R (0x60388)
+#define CNENDINV    PIC32_R (0x6038C)
+#define CNSTATD     PIC32_R (0x60390) /* Port D: status */
+#define CNSTATDCLR  PIC32_R (0x60394)
+#define CNSTATDSET  PIC32_R (0x60398)
+#define CNSTATDINV  PIC32_R (0x6039C)
 
-#define ANSELE		PIC32_R (0x60400) /* Port E: analog select */
-#define ANSELECLR	PIC32_R (0x60404)
-#define ANSELESET	PIC32_R (0x60408)
-#define ANSELEINV	PIC32_R (0x6040C)
-#define TRISE		PIC32_R (0x60410) /* Port E: mask of inputs */
-#define TRISECLR	PIC32_R (0x60414)
-#define TRISESET	PIC32_R (0x60418)
-#define TRISEINV	PIC32_R (0x6041C)
-#define PORTE		PIC32_R (0x60420) /* Port E: read inputs, write outputs */
-#define PORTECLR	PIC32_R (0x60424)
-#define PORTESET	PIC32_R (0x60428)
-#define PORTEINV	PIC32_R (0x6042C)
-#define LATE		PIC32_R (0x60430) /* Port E: read/write outputs */
-#define LATECLR		PIC32_R (0x60434)
-#define LATESET		PIC32_R (0x60438)
-#define LATEINV		PIC32_R (0x6043C)
-#define ODCE		PIC32_R (0x60440) /* Port E: open drain configuration */
-#define ODCECLR		PIC32_R (0x60444)
-#define ODCESET		PIC32_R (0x60448)
-#define ODCEINV		PIC32_R (0x6044C)
-#define CNPUE		PIC32_R (0x60450) /* Port E: input pin pull-up enable */
-#define CNPUECLR	PIC32_R (0x60454)
-#define CNPUESET	PIC32_R (0x60458)
-#define CNPUEINV	PIC32_R (0x6045C)
-#define CNPDE		PIC32_R (0x60460) /* Port E: input pin pull-down enable */
-#define CNPDECLR	PIC32_R (0x60464)
-#define CNPDESET	PIC32_R (0x60468)
-#define CNPDEINV	PIC32_R (0x6046C)
-#define CNCONE		PIC32_R (0x60470) /* Port E: interrupt-on-change control */
-#define CNCONECLR	PIC32_R (0x60474)
-#define CNCONESET	PIC32_R (0x60478)
-#define CNCONEINV	PIC32_R (0x6047C)
-#define CNENE		PIC32_R (0x60480) /* Port E: input change interrupt enable */
-#define CNENECLR	PIC32_R (0x60484)
-#define CNENESET	PIC32_R (0x60488)
-#define CNENEINV	PIC32_R (0x6048C)
-#define CNSTATE		PIC32_R (0x60490) /* Port E: status */
-#define CNSTATECLR	PIC32_R (0x60494)
-#define CNSTATESET	PIC32_R (0x60498)
-#define CNSTATEINV	PIC32_R (0x6049C)
+#define ANSELE      PIC32_R (0x60400) /* Port E: analog select */
+#define ANSELECLR   PIC32_R (0x60404)
+#define ANSELESET   PIC32_R (0x60408)
+#define ANSELEINV   PIC32_R (0x6040C)
+#define TRISE       PIC32_R (0x60410) /* Port E: mask of inputs */
+#define TRISECLR    PIC32_R (0x60414)
+#define TRISESET    PIC32_R (0x60418)
+#define TRISEINV    PIC32_R (0x6041C)
+#define PORTE       PIC32_R (0x60420) /* Port E: read inputs, write outputs */
+#define PORTECLR    PIC32_R (0x60424)
+#define PORTESET    PIC32_R (0x60428)
+#define PORTEINV    PIC32_R (0x6042C)
+#define LATE        PIC32_R (0x60430) /* Port E: read/write outputs */
+#define LATECLR     PIC32_R (0x60434)
+#define LATESET     PIC32_R (0x60438)
+#define LATEINV     PIC32_R (0x6043C)
+#define ODCE        PIC32_R (0x60440) /* Port E: open drain configuration */
+#define ODCECLR     PIC32_R (0x60444)
+#define ODCESET     PIC32_R (0x60448)
+#define ODCEINV     PIC32_R (0x6044C)
+#define CNPUE       PIC32_R (0x60450) /* Port E: input pin pull-up enable */
+#define CNPUECLR    PIC32_R (0x60454)
+#define CNPUESET    PIC32_R (0x60458)
+#define CNPUEINV    PIC32_R (0x6045C)
+#define CNPDE       PIC32_R (0x60460) /* Port E: input pin pull-down enable */
+#define CNPDECLR    PIC32_R (0x60464)
+#define CNPDESET    PIC32_R (0x60468)
+#define CNPDEINV    PIC32_R (0x6046C)
+#define CNCONE      PIC32_R (0x60470) /* Port E: interrupt-on-change control */
+#define CNCONECLR   PIC32_R (0x60474)
+#define CNCONESET   PIC32_R (0x60478)
+#define CNCONEINV   PIC32_R (0x6047C)
+#define CNENE       PIC32_R (0x60480) /* Port E: input change interrupt enable */
+#define CNENECLR    PIC32_R (0x60484)
+#define CNENESET    PIC32_R (0x60488)
+#define CNENEINV    PIC32_R (0x6048C)
+#define CNSTATE     PIC32_R (0x60490) /* Port E: status */
+#define CNSTATECLR  PIC32_R (0x60494)
+#define CNSTATESET  PIC32_R (0x60498)
+#define CNSTATEINV  PIC32_R (0x6049C)
 
-#define ANSELF		PIC32_R (0x60500) /* Port F: analog select */
-#define ANSELFCLR	PIC32_R (0x60504)
-#define ANSELFSET	PIC32_R (0x60508)
-#define ANSELFINV	PIC32_R (0x6050C)
-#define TRISF		PIC32_R (0x60510) /* Port F: mask of inputs */
-#define TRISFCLR	PIC32_R (0x60514)
-#define TRISFSET	PIC32_R (0x60518)
-#define TRISFINV	PIC32_R (0x6051C)
-#define PORTF		PIC32_R (0x60520) /* Port F: read inputs, write outputs */
-#define PORTFCLR	PIC32_R (0x60524)
-#define PORTFSET	PIC32_R (0x60528)
-#define PORTFINV	PIC32_R (0x6052C)
-#define LATF		PIC32_R (0x60530) /* Port F: read/write outputs */
-#define LATFCLR		PIC32_R (0x60534)
-#define LATFSET		PIC32_R (0x60538)
-#define LATFINV		PIC32_R (0x6053C)
-#define ODCF		PIC32_R (0x60540) /* Port F: open drain configuration */
-#define ODCFCLR		PIC32_R (0x60544)
-#define ODCFSET		PIC32_R (0x60548)
-#define ODCFINV		PIC32_R (0x6054C)
-#define CNPUF		PIC32_R (0x60550) /* Port F: input pin pull-up enable */
-#define CNPUFCLR	PIC32_R (0x60554)
-#define CNPUFSET	PIC32_R (0x60558)
-#define CNPUFINV	PIC32_R (0x6055C)
-#define CNPDF		PIC32_R (0x60560) /* Port F: input pin pull-down enable */
-#define CNPDFCLR	PIC32_R (0x60564)
-#define CNPDFSET	PIC32_R (0x60568)
-#define CNPDFINV	PIC32_R (0x6056C)
-#define CNCONF		PIC32_R (0x60570) /* Port F: interrupt-on-change control */
-#define CNCONFCLR	PIC32_R (0x60574)
-#define CNCONFSET	PIC32_R (0x60578)
-#define CNCONFINV	PIC32_R (0x6057C)
-#define CNENF		PIC32_R (0x60580) /* Port F: input change interrupt enable */
-#define CNENFCLR	PIC32_R (0x60584)
-#define CNENFSET	PIC32_R (0x60588)
-#define CNENFINV	PIC32_R (0x6058C)
-#define CNSTATF		PIC32_R (0x60590) /* Port F: status */
-#define CNSTATFCLR	PIC32_R (0x60594)
-#define CNSTATFSET	PIC32_R (0x60598)
-#define CNSTATFINV	PIC32_R (0x6059C)
+#define ANSELF      PIC32_R (0x60500) /* Port F: analog select */
+#define ANSELFCLR   PIC32_R (0x60504)
+#define ANSELFSET   PIC32_R (0x60508)
+#define ANSELFINV   PIC32_R (0x6050C)
+#define TRISF       PIC32_R (0x60510) /* Port F: mask of inputs */
+#define TRISFCLR    PIC32_R (0x60514)
+#define TRISFSET    PIC32_R (0x60518)
+#define TRISFINV    PIC32_R (0x6051C)
+#define PORTF       PIC32_R (0x60520) /* Port F: read inputs, write outputs */
+#define PORTFCLR    PIC32_R (0x60524)
+#define PORTFSET    PIC32_R (0x60528)
+#define PORTFINV    PIC32_R (0x6052C)
+#define LATF        PIC32_R (0x60530) /* Port F: read/write outputs */
+#define LATFCLR     PIC32_R (0x60534)
+#define LATFSET     PIC32_R (0x60538)
+#define LATFINV     PIC32_R (0x6053C)
+#define ODCF        PIC32_R (0x60540) /* Port F: open drain configuration */
+#define ODCFCLR     PIC32_R (0x60544)
+#define ODCFSET     PIC32_R (0x60548)
+#define ODCFINV     PIC32_R (0x6054C)
+#define CNPUF       PIC32_R (0x60550) /* Port F: input pin pull-up enable */
+#define CNPUFCLR    PIC32_R (0x60554)
+#define CNPUFSET    PIC32_R (0x60558)
+#define CNPUFINV    PIC32_R (0x6055C)
+#define CNPDF       PIC32_R (0x60560) /* Port F: input pin pull-down enable */
+#define CNPDFCLR    PIC32_R (0x60564)
+#define CNPDFSET    PIC32_R (0x60568)
+#define CNPDFINV    PIC32_R (0x6056C)
+#define CNCONF      PIC32_R (0x60570) /* Port F: interrupt-on-change control */
+#define CNCONFCLR   PIC32_R (0x60574)
+#define CNCONFSET   PIC32_R (0x60578)
+#define CNCONFINV   PIC32_R (0x6057C)
+#define CNENF       PIC32_R (0x60580) /* Port F: input change interrupt enable */
+#define CNENFCLR    PIC32_R (0x60584)
+#define CNENFSET    PIC32_R (0x60588)
+#define CNENFINV    PIC32_R (0x6058C)
+#define CNSTATF     PIC32_R (0x60590) /* Port F: status */
+#define CNSTATFCLR  PIC32_R (0x60594)
+#define CNSTATFSET  PIC32_R (0x60598)
+#define CNSTATFINV  PIC32_R (0x6059C)
 
-#define ANSELG		PIC32_R (0x60600) /* Port G: analog select */
-#define ANSELGCLR	PIC32_R (0x60604)
-#define ANSELGSET	PIC32_R (0x60608)
-#define ANSELGINV	PIC32_R (0x6060C)
-#define TRISG		PIC32_R (0x60610) /* Port G: mask of inputs */
-#define TRISGCLR	PIC32_R (0x60614)
-#define TRISGSET	PIC32_R (0x60618)
-#define TRISGINV	PIC32_R (0x6061C)
-#define PORTG		PIC32_R (0x60620) /* Port G: read inputs, write outputs */
-#define PORTGCLR	PIC32_R (0x60624)
-#define PORTGSET	PIC32_R (0x60628)
-#define PORTGINV	PIC32_R (0x6062C)
-#define LATG		PIC32_R (0x60630) /* Port G: read/write outputs */
-#define LATGCLR		PIC32_R (0x60634)
-#define LATGSET		PIC32_R (0x60638)
-#define LATGINV		PIC32_R (0x6063C)
-#define ODCG		PIC32_R (0x60640) /* Port G: open drain configuration */
-#define ODCGCLR		PIC32_R (0x60644)
-#define ODCGSET		PIC32_R (0x60648)
-#define ODCGINV		PIC32_R (0x6064C)
-#define CNPUG		PIC32_R (0x60650) /* Port G: input pin pull-up enable */
-#define CNPUGCLR	PIC32_R (0x60654)
-#define CNPUGSET	PIC32_R (0x60658)
-#define CNPUGINV	PIC32_R (0x6065C)
-#define CNPDG		PIC32_R (0x60660) /* Port G: input pin pull-down enable */
-#define CNPDGCLR	PIC32_R (0x60664)
-#define CNPDGSET	PIC32_R (0x60668)
-#define CNPDGINV	PIC32_R (0x6066C)
-#define CNCONG		PIC32_R (0x60670) /* Port G: interrupt-on-change control */
-#define CNCONGCLR	PIC32_R (0x60674)
-#define CNCONGSET	PIC32_R (0x60678)
-#define CNCONGINV	PIC32_R (0x6067C)
-#define CNENG		PIC32_R (0x60680) /* Port G: input change interrupt enable */
-#define CNENGCLR	PIC32_R (0x60684)
-#define CNENGSET	PIC32_R (0x60688)
-#define CNENGINV	PIC32_R (0x6068C)
-#define CNSTATG		PIC32_R (0x60690) /* Port G: status */
-#define CNSTATGCLR	PIC32_R (0x60694)
-#define CNSTATGSET	PIC32_R (0x60698)
-#define CNSTATGINV	PIC32_R (0x6069C)
+#define ANSELG      PIC32_R (0x60600) /* Port G: analog select */
+#define ANSELGCLR   PIC32_R (0x60604)
+#define ANSELGSET   PIC32_R (0x60608)
+#define ANSELGINV   PIC32_R (0x6060C)
+#define TRISG       PIC32_R (0x60610) /* Port G: mask of inputs */
+#define TRISGCLR    PIC32_R (0x60614)
+#define TRISGSET    PIC32_R (0x60618)
+#define TRISGINV    PIC32_R (0x6061C)
+#define PORTG       PIC32_R (0x60620) /* Port G: read inputs, write outputs */
+#define PORTGCLR    PIC32_R (0x60624)
+#define PORTGSET    PIC32_R (0x60628)
+#define PORTGINV    PIC32_R (0x6062C)
+#define LATG        PIC32_R (0x60630) /* Port G: read/write outputs */
+#define LATGCLR     PIC32_R (0x60634)
+#define LATGSET     PIC32_R (0x60638)
+#define LATGINV     PIC32_R (0x6063C)
+#define ODCG        PIC32_R (0x60640) /* Port G: open drain configuration */
+#define ODCGCLR     PIC32_R (0x60644)
+#define ODCGSET     PIC32_R (0x60648)
+#define ODCGINV     PIC32_R (0x6064C)
+#define CNPUG       PIC32_R (0x60650) /* Port G: input pin pull-up enable */
+#define CNPUGCLR    PIC32_R (0x60654)
+#define CNPUGSET    PIC32_R (0x60658)
+#define CNPUGINV    PIC32_R (0x6065C)
+#define CNPDG       PIC32_R (0x60660) /* Port G: input pin pull-down enable */
+#define CNPDGCLR    PIC32_R (0x60664)
+#define CNPDGSET    PIC32_R (0x60668)
+#define CNPDGINV    PIC32_R (0x6066C)
+#define CNCONG      PIC32_R (0x60670) /* Port G: interrupt-on-change control */
+#define CNCONGCLR   PIC32_R (0x60674)
+#define CNCONGSET   PIC32_R (0x60678)
+#define CNCONGINV   PIC32_R (0x6067C)
+#define CNENG       PIC32_R (0x60680) /* Port G: input change interrupt enable */
+#define CNENGCLR    PIC32_R (0x60684)
+#define CNENGSET    PIC32_R (0x60688)
+#define CNENGINV    PIC32_R (0x6068C)
+#define CNSTATG     PIC32_R (0x60690) /* Port G: status */
+#define CNSTATGCLR  PIC32_R (0x60694)
+#define CNSTATGSET  PIC32_R (0x60698)
+#define CNSTATGINV  PIC32_R (0x6069C)
 
-#define ANSELH		PIC32_R (0x60700) /* Port H: analog select */
-#define ANSELHCLR	PIC32_R (0x60704)
-#define ANSELHSET	PIC32_R (0x60708)
-#define ANSELHINV	PIC32_R (0x6070C)
-#define TRISH		PIC32_R (0x60710) /* Port H: mask of inputs */
-#define TRISHCLR	PIC32_R (0x60714)
-#define TRISHSET	PIC32_R (0x60718)
-#define TRISHINV	PIC32_R (0x6071C)
-#define PORTH		PIC32_R (0x60720) /* Port H: read inputs, write outputs */
-#define PORTHCLR	PIC32_R (0x60724)
-#define PORTHSET	PIC32_R (0x60728)
-#define PORTHINV	PIC32_R (0x6072C)
-#define LATH		PIC32_R (0x60730) /* Port H: read/write outputs */
-#define LATHCLR		PIC32_R (0x60734)
-#define LATHSET		PIC32_R (0x60738)
-#define LATHINV		PIC32_R (0x6073C)
-#define ODCH		PIC32_R (0x60740) /* Port H: open drain configuration */
-#define ODCHCLR		PIC32_R (0x60744)
-#define ODCHSET		PIC32_R (0x60748)
-#define ODCHINV		PIC32_R (0x6074C)
-#define CNPUH		PIC32_R (0x60750) /* Port H: input pin pull-up enable */
-#define CNPUHCLR	PIC32_R (0x60754)
-#define CNPUHSET	PIC32_R (0x60758)
-#define CNPUHINV	PIC32_R (0x6075C)
-#define CNPDH		PIC32_R (0x60760) /* Port H: input pin pull-down enable */
-#define CNPDHCLR	PIC32_R (0x60764)
-#define CNPDHSET	PIC32_R (0x60768)
-#define CNPDHINV	PIC32_R (0x6076C)
-#define CNCONH		PIC32_R (0x60770) /* Port H: interrupt-on-change control */
-#define CNCONHCLR	PIC32_R (0x60774)
-#define CNCONHSET	PIC32_R (0x60778)
-#define CNCONHINV	PIC32_R (0x6077C)
-#define CNENH		PIC32_R (0x60780) /* Port H: input change interrupt enable */
-#define CNENHCLR	PIC32_R (0x60784)
-#define CNENHSET	PIC32_R (0x60788)
-#define CNENHINV	PIC32_R (0x6078C)
-#define CNSTATH		PIC32_R (0x60790) /* Port H: status */
-#define CNSTATHCLR	PIC32_R (0x60794)
-#define CNSTATHSET	PIC32_R (0x60798)
-#define CNSTATHINV	PIC32_R (0x6079C)
+#define ANSELH      PIC32_R (0x60700) /* Port H: analog select */
+#define ANSELHCLR   PIC32_R (0x60704)
+#define ANSELHSET   PIC32_R (0x60708)
+#define ANSELHINV   PIC32_R (0x6070C)
+#define TRISH       PIC32_R (0x60710) /* Port H: mask of inputs */
+#define TRISHCLR    PIC32_R (0x60714)
+#define TRISHSET    PIC32_R (0x60718)
+#define TRISHINV    PIC32_R (0x6071C)
+#define PORTH       PIC32_R (0x60720) /* Port H: read inputs, write outputs */
+#define PORTHCLR    PIC32_R (0x60724)
+#define PORTHSET    PIC32_R (0x60728)
+#define PORTHINV    PIC32_R (0x6072C)
+#define LATH        PIC32_R (0x60730) /* Port H: read/write outputs */
+#define LATHCLR     PIC32_R (0x60734)
+#define LATHSET     PIC32_R (0x60738)
+#define LATHINV     PIC32_R (0x6073C)
+#define ODCH        PIC32_R (0x60740) /* Port H: open drain configuration */
+#define ODCHCLR     PIC32_R (0x60744)
+#define ODCHSET     PIC32_R (0x60748)
+#define ODCHINV     PIC32_R (0x6074C)
+#define CNPUH       PIC32_R (0x60750) /* Port H: input pin pull-up enable */
+#define CNPUHCLR    PIC32_R (0x60754)
+#define CNPUHSET    PIC32_R (0x60758)
+#define CNPUHINV    PIC32_R (0x6075C)
+#define CNPDH       PIC32_R (0x60760) /* Port H: input pin pull-down enable */
+#define CNPDHCLR    PIC32_R (0x60764)
+#define CNPDHSET    PIC32_R (0x60768)
+#define CNPDHINV    PIC32_R (0x6076C)
+#define CNCONH      PIC32_R (0x60770) /* Port H: interrupt-on-change control */
+#define CNCONHCLR   PIC32_R (0x60774)
+#define CNCONHSET   PIC32_R (0x60778)
+#define CNCONHINV   PIC32_R (0x6077C)
+#define CNENH       PIC32_R (0x60780) /* Port H: input change interrupt enable */
+#define CNENHCLR    PIC32_R (0x60784)
+#define CNENHSET    PIC32_R (0x60788)
+#define CNENHINV    PIC32_R (0x6078C)
+#define CNSTATH     PIC32_R (0x60790) /* Port H: status */
+#define CNSTATHCLR  PIC32_R (0x60794)
+#define CNSTATHSET  PIC32_R (0x60798)
+#define CNSTATHINV  PIC32_R (0x6079C)
 
-#define ANSELJ		PIC32_R (0x60800) /* Port J: analog select */
-#define ANSELJCLR	PIC32_R (0x60804)
-#define ANSELJSET	PIC32_R (0x60808)
-#define ANSELJINV	PIC32_R (0x6080C)
-#define TRISJ		PIC32_R (0x60810) /* Port J: mask of inputs */
-#define TRISJCLR	PIC32_R (0x60814)
-#define TRISJSET	PIC32_R (0x60818)
-#define TRISJINV	PIC32_R (0x6081C)
-#define PORTJ		PIC32_R (0x60820) /* Port J: read inputs, write outputs */
-#define PORTJCLR	PIC32_R (0x60824)
-#define PORTJSET	PIC32_R (0x60828)
-#define PORTJINV	PIC32_R (0x6082C)
-#define LATJ		PIC32_R (0x60830) /* Port J: read/write outputs */
-#define LATJCLR		PIC32_R (0x60834)
-#define LATJSET		PIC32_R (0x60838)
-#define LATJINV		PIC32_R (0x6083C)
-#define ODCJ		PIC32_R (0x60840) /* Port J: open drain configuration */
-#define ODCJCLR		PIC32_R (0x60844)
-#define ODCJSET		PIC32_R (0x60848)
-#define ODCJINV		PIC32_R (0x6084C)
-#define CNPUJ		PIC32_R (0x60850) /* Port J: input pin pull-up enable */
-#define CNPUJCLR	PIC32_R (0x60854)
-#define CNPUJSET	PIC32_R (0x60858)
-#define CNPUJINV	PIC32_R (0x6085C)
-#define CNPDJ		PIC32_R (0x60860) /* Port J: input pin pull-down enable */
-#define CNPDJCLR	PIC32_R (0x60864)
-#define CNPDJSET	PIC32_R (0x60868)
-#define CNPDJINV	PIC32_R (0x6086C)
-#define CNCONJ		PIC32_R (0x60870) /* Port J: interrupt-on-change control */
-#define CNCONJCLR	PIC32_R (0x60874)
-#define CNCONJSET	PIC32_R (0x60878)
-#define CNCONJINV	PIC32_R (0x6087C)
-#define CNENJ		PIC32_R (0x60880) /* Port J: input change interrupt enable */
-#define CNENJCLR	PIC32_R (0x60884)
-#define CNENJSET	PIC32_R (0x60888)
-#define CNENJINV	PIC32_R (0x6088C)
-#define CNSTATJ		PIC32_R (0x60890) /* Port J: status */
-#define CNSTATJCLR	PIC32_R (0x60894)
-#define CNSTATJSET	PIC32_R (0x60898)
-#define CNSTATJINV	PIC32_R (0x6089C)
+#define ANSELJ      PIC32_R (0x60800) /* Port J: analog select */
+#define ANSELJCLR   PIC32_R (0x60804)
+#define ANSELJSET   PIC32_R (0x60808)
+#define ANSELJINV   PIC32_R (0x6080C)
+#define TRISJ       PIC32_R (0x60810) /* Port J: mask of inputs */
+#define TRISJCLR    PIC32_R (0x60814)
+#define TRISJSET    PIC32_R (0x60818)
+#define TRISJINV    PIC32_R (0x6081C)
+#define PORTJ       PIC32_R (0x60820) /* Port J: read inputs, write outputs */
+#define PORTJCLR    PIC32_R (0x60824)
+#define PORTJSET    PIC32_R (0x60828)
+#define PORTJINV    PIC32_R (0x6082C)
+#define LATJ        PIC32_R (0x60830) /* Port J: read/write outputs */
+#define LATJCLR     PIC32_R (0x60834)
+#define LATJSET     PIC32_R (0x60838)
+#define LATJINV     PIC32_R (0x6083C)
+#define ODCJ        PIC32_R (0x60840) /* Port J: open drain configuration */
+#define ODCJCLR     PIC32_R (0x60844)
+#define ODCJSET     PIC32_R (0x60848)
+#define ODCJINV     PIC32_R (0x6084C)
+#define CNPUJ       PIC32_R (0x60850) /* Port J: input pin pull-up enable */
+#define CNPUJCLR    PIC32_R (0x60854)
+#define CNPUJSET    PIC32_R (0x60858)
+#define CNPUJINV    PIC32_R (0x6085C)
+#define CNPDJ       PIC32_R (0x60860) /* Port J: input pin pull-down enable */
+#define CNPDJCLR    PIC32_R (0x60864)
+#define CNPDJSET    PIC32_R (0x60868)
+#define CNPDJINV    PIC32_R (0x6086C)
+#define CNCONJ      PIC32_R (0x60870) /* Port J: interrupt-on-change control */
+#define CNCONJCLR   PIC32_R (0x60874)
+#define CNCONJSET   PIC32_R (0x60878)
+#define CNCONJINV   PIC32_R (0x6087C)
+#define CNENJ       PIC32_R (0x60880) /* Port J: input change interrupt enable */
+#define CNENJCLR    PIC32_R (0x60884)
+#define CNENJSET    PIC32_R (0x60888)
+#define CNENJINV    PIC32_R (0x6088C)
+#define CNSTATJ     PIC32_R (0x60890) /* Port J: status */
+#define CNSTATJCLR  PIC32_R (0x60894)
+#define CNSTATJSET  PIC32_R (0x60898)
+#define CNSTATJINV  PIC32_R (0x6089C)
 
-#define TRISK		PIC32_R (0x60910) /* Port K: mask of inputs */
-#define TRISKCLR	PIC32_R (0x60914)
-#define TRISKSET	PIC32_R (0x60918)
-#define TRISKINV	PIC32_R (0x6091C)
-#define PORTK		PIC32_R (0x60920) /* Port K: read inputs, write outputs */
-#define PORTKCLR	PIC32_R (0x60924)
-#define PORTKSET	PIC32_R (0x60928)
-#define PORTKINV	PIC32_R (0x6092C)
-#define LATK		PIC32_R (0x60930) /* Port K: read/write outputs */
-#define LATKCLR		PIC32_R (0x60934)
-#define LATKSET		PIC32_R (0x60938)
-#define LATKINV		PIC32_R (0x6093C)
-#define ODCK		PIC32_R (0x60940) /* Port K: open drain configuration */
-#define ODCKCLR		PIC32_R (0x60944)
-#define ODCKSET		PIC32_R (0x60948)
-#define ODCKINV		PIC32_R (0x6094C)
-#define CNPUK		PIC32_R (0x60950) /* Port K: input pin pull-up enable */
-#define CNPUKCLR	PIC32_R (0x60954)
-#define CNPUKSET	PIC32_R (0x60958)
-#define CNPUKINV	PIC32_R (0x6095C)
-#define CNPDK		PIC32_R (0x60960) /* Port K: input pin pull-down enable */
-#define CNPDKCLR	PIC32_R (0x60964)
-#define CNPDKSET	PIC32_R (0x60968)
-#define CNPDKINV	PIC32_R (0x6096C)
-#define CNCONK		PIC32_R (0x60970) /* Port K: interrupt-on-change control */
-#define CNCONKCLR	PIC32_R (0x60974)
-#define CNCONKSET	PIC32_R (0x60978)
-#define CNCONKINV	PIC32_R (0x6097C)
-#define CNENK		PIC32_R (0x60980) /* Port K: input change interrupt enable */
-#define CNENKCLR	PIC32_R (0x60984)
-#define CNENKSET	PIC32_R (0x60988)
-#define CNENKINV	PIC32_R (0x6098C)
-#define CNSTATK		PIC32_R (0x60990) /* Port K: status */
-#define CNSTATKCLR	PIC32_R (0x60994)
-#define CNSTATKSET	PIC32_R (0x60998)
-#define CNSTATKINV	PIC32_R (0x6099C)
+#define TRISK       PIC32_R (0x60910) /* Port K: mask of inputs */
+#define TRISKCLR    PIC32_R (0x60914)
+#define TRISKSET    PIC32_R (0x60918)
+#define TRISKINV    PIC32_R (0x6091C)
+#define PORTK       PIC32_R (0x60920) /* Port K: read inputs, write outputs */
+#define PORTKCLR    PIC32_R (0x60924)
+#define PORTKSET    PIC32_R (0x60928)
+#define PORTKINV    PIC32_R (0x6092C)
+#define LATK        PIC32_R (0x60930) /* Port K: read/write outputs */
+#define LATKCLR     PIC32_R (0x60934)
+#define LATKSET     PIC32_R (0x60938)
+#define LATKINV     PIC32_R (0x6093C)
+#define ODCK        PIC32_R (0x60940) /* Port K: open drain configuration */
+#define ODCKCLR     PIC32_R (0x60944)
+#define ODCKSET     PIC32_R (0x60948)
+#define ODCKINV     PIC32_R (0x6094C)
+#define CNPUK       PIC32_R (0x60950) /* Port K: input pin pull-up enable */
+#define CNPUKCLR    PIC32_R (0x60954)
+#define CNPUKSET    PIC32_R (0x60958)
+#define CNPUKINV    PIC32_R (0x6095C)
+#define CNPDK       PIC32_R (0x60960) /* Port K: input pin pull-down enable */
+#define CNPDKCLR    PIC32_R (0x60964)
+#define CNPDKSET    PIC32_R (0x60968)
+#define CNPDKINV    PIC32_R (0x6096C)
+#define CNCONK      PIC32_R (0x60970) /* Port K: interrupt-on-change control */
+#define CNCONKCLR   PIC32_R (0x60974)
+#define CNCONKSET   PIC32_R (0x60978)
+#define CNCONKINV   PIC32_R (0x6097C)
+#define CNENK       PIC32_R (0x60980) /* Port K: input change interrupt enable */
+#define CNENKCLR    PIC32_R (0x60984)
+#define CNENKSET    PIC32_R (0x60988)
+#define CNENKINV    PIC32_R (0x6098C)
+#define CNSTATK     PIC32_R (0x60990) /* Port K: status */
+#define CNSTATKCLR  PIC32_R (0x60994)
+#define CNSTATKSET  PIC32_R (0x60998)
+#define CNSTATKINV  PIC32_R (0x6099C)
 
 /*--------------------------------------
  * Parallel master port registers.
  */
-#define PMCON		PIC32_R (0x2E000) /* Control */
-#define PMCONCLR	PIC32_R (0x2E004)
-#define PMCONSET	PIC32_R (0x2E008)
-#define PMCONINV	PIC32_R (0x2E00C)
-#define PMMODE		PIC32_R (0x2E010) /* Mode */
-#define PMMODECLR	PIC32_R (0x2E014)
-#define PMMODESET	PIC32_R (0x2E018)
-#define PMMODEINV	PIC32_R (0x2E01C)
-#define PMADDR		PIC32_R (0x2E020) /* Address */
-#define PMADDRCLR	PIC32_R (0x2E024)
-#define PMADDRSET	PIC32_R (0x2E028)
-#define PMADDRINV	PIC32_R (0x2E02C)
-#define PMDOUT		PIC32_R (0x2E030) /* Data output */
-#define PMDOUTCLR	PIC32_R (0x2E034)
-#define PMDOUTSET	PIC32_R (0x2E038)
-#define PMDOUTINV	PIC32_R (0x2E03C)
-#define PMDIN		PIC32_R (0x2E040) /* Data input */
-#define PMDINCLR	PIC32_R (0x2E044)
-#define PMDINSET	PIC32_R (0x2E048)
-#define PMDININV	PIC32_R (0x2E04C)
-#define PMAEN		PIC32_R (0x2E050) /* Pin enable */
-#define PMAENCLR	PIC32_R (0x2E054)
-#define PMAENSET	PIC32_R (0x2E058)
-#define PMAENINV	PIC32_R (0x2E05C)
-#define PMSTAT		PIC32_R (0x2E060) /* Status (slave only) */
-#define PMSTATCLR	PIC32_R (0x2E064)
-#define PMSTATSET	PIC32_R (0x2E068)
-#define PMSTATINV	PIC32_R (0x2E06C)
+#define PMCON       PIC32_R (0x2E000) /* Control */
+#define PMCONCLR    PIC32_R (0x2E004)
+#define PMCONSET    PIC32_R (0x2E008)
+#define PMCONINV    PIC32_R (0x2E00C)
+#define PMMODE      PIC32_R (0x2E010) /* Mode */
+#define PMMODECLR   PIC32_R (0x2E014)
+#define PMMODESET   PIC32_R (0x2E018)
+#define PMMODEINV   PIC32_R (0x2E01C)
+#define PMADDR      PIC32_R (0x2E020) /* Address */
+#define PMADDRCLR   PIC32_R (0x2E024)
+#define PMADDRSET   PIC32_R (0x2E028)
+#define PMADDRINV   PIC32_R (0x2E02C)
+#define PMDOUT      PIC32_R (0x2E030) /* Data output */
+#define PMDOUTCLR   PIC32_R (0x2E034)
+#define PMDOUTSET   PIC32_R (0x2E038)
+#define PMDOUTINV   PIC32_R (0x2E03C)
+#define PMDIN       PIC32_R (0x2E040) /* Data input */
+#define PMDINCLR    PIC32_R (0x2E044)
+#define PMDINSET    PIC32_R (0x2E048)
+#define PMDININV    PIC32_R (0x2E04C)
+#define PMAEN       PIC32_R (0x2E050) /* Pin enable */
+#define PMAENCLR    PIC32_R (0x2E054)
+#define PMAENSET    PIC32_R (0x2E058)
+#define PMAENINV    PIC32_R (0x2E05C)
+#define PMSTAT      PIC32_R (0x2E060) /* Status (slave only) */
+#define PMSTATCLR   PIC32_R (0x2E064)
+#define PMSTATSET   PIC32_R (0x2E068)
+#define PMSTATINV   PIC32_R (0x2E06C)
 
 /*
  * PMP Control register.
  */
-#define PIC32_PMCON_RDSP	0x0001 /* Read strobe polarity active-high */
-#define PIC32_PMCON_WRSP	0x0002 /* Write strobe polarity active-high */
-#define PIC32_PMCON_CS1P	0x0008 /* Chip select 0 polarity active-high */
-#define PIC32_PMCON_CS2P	0x0010 /* Chip select 1 polarity active-high */
-#define PIC32_PMCON_ALP		0x0020 /* Address latch polarity active-high */
-#define PIC32_PMCON_CSF		0x00C0 /* Chip select function bitmask: */
-#define PIC32_PMCON_CSF_NONE	0x0000 /* PMCS2 and PMCS1 as A[15:14] */
-#define PIC32_PMCON_CSF_CS2	0x0040 /* PMCS2 as chip select */
-#define PIC32_PMCON_CSF_CS21	0x0080 /* PMCS2 and PMCS1 as chip select */
-#define PIC32_PMCON_PTRDEN	0x0100 /* Read/write strobe port enable */
-#define PIC32_PMCON_PTWREN	0x0200 /* Write enable strobe port enable */
-#define PIC32_PMCON_PMPTTL	0x0400 /* TTL input buffer select */
-#define PIC32_PMCON_ADRMUX	0x1800 /* Address/data mux selection bitmask: */
-#define PIC32_PMCON_ADRMUX_NONE	0x0000 /* Address and data separate */
-#define PIC32_PMCON_ADRMUX_AD	0x0800 /* Lower address on PMD[7:0], high on PMA[15:8] */
-#define PIC32_PMCON_ADRMUX_D8	0x1000 /* All address on PMD[7:0] */
-#define PIC32_PMCON_ADRMUX_D16	0x1800 /* All address on PMD[15:0] */
-#define PIC32_PMCON_SIDL	0x2000 /* Stop in idle */
-#define PIC32_PMCON_FRZ		0x4000 /* Freeze in debug exception */
-#define PIC32_PMCON_ON		0x8000 /* Parallel master port enable */
+#define PIC32_PMCON_RDSP    0x0001 /* Read strobe polarity active-high */
+#define PIC32_PMCON_WRSP    0x0002 /* Write strobe polarity active-high */
+#define PIC32_PMCON_CS1P    0x0008 /* Chip select 0 polarity active-high */
+#define PIC32_PMCON_CS2P    0x0010 /* Chip select 1 polarity active-high */
+#define PIC32_PMCON_ALP     0x0020 /* Address latch polarity active-high */
+#define PIC32_PMCON_CSF     0x00C0 /* Chip select function bitmask: */
+#define PIC32_PMCON_CSF_NONE    0x0000 /* PMCS2 and PMCS1 as A[15:14] */
+#define PIC32_PMCON_CSF_CS2 0x0040 /* PMCS2 as chip select */
+#define PIC32_PMCON_CSF_CS21    0x0080 /* PMCS2 and PMCS1 as chip select */
+#define PIC32_PMCON_PTRDEN  0x0100 /* Read/write strobe port enable */
+#define PIC32_PMCON_PTWREN  0x0200 /* Write enable strobe port enable */
+#define PIC32_PMCON_PMPTTL  0x0400 /* TTL input buffer select */
+#define PIC32_PMCON_ADRMUX  0x1800 /* Address/data mux selection bitmask: */
+#define PIC32_PMCON_ADRMUX_NONE 0x0000 /* Address and data separate */
+#define PIC32_PMCON_ADRMUX_AD   0x0800 /* Lower address on PMD[7:0], high on PMA[15:8] */
+#define PIC32_PMCON_ADRMUX_D8   0x1000 /* All address on PMD[7:0] */
+#define PIC32_PMCON_ADRMUX_D16  0x1800 /* All address on PMD[15:0] */
+#define PIC32_PMCON_SIDL    0x2000 /* Stop in idle */
+#define PIC32_PMCON_FRZ     0x4000 /* Freeze in debug exception */
+#define PIC32_PMCON_ON      0x8000 /* Parallel master port enable */
 
 /*
  * PMP Mode register.
  */
-#define PIC32_PMMODE_WAITE(x)	((x)<<0) /* Wait states: data hold after RW strobe */
-#define PIC32_PMMODE_WAITM(x)	((x)<<2) /* Wait states: data RW strobe */
-#define PIC32_PMMODE_WAITB(x)	((x)<<6) /* Wait states: data setup to RW strobe */
-#define PIC32_PMMODE_MODE	0x0300	/* Mode select bitmask: */
-#define PIC32_PMMODE_MODE_SLAVE	0x0000	/* Legacy slave */
-#define PIC32_PMMODE_MODE_SLENH	0x0100	/* Enhanced slave */
-#define PIC32_PMMODE_MODE_MAST2	0x0200	/* Master mode 2 */
-#define PIC32_PMMODE_MODE_MAST1	0x0300	/* Master mode 1 */
-#define PIC32_PMMODE_MODE16	0x0400	/* 16-bit mode */
-#define PIC32_PMMODE_INCM	0x1800	/* Address increment mode bitmask: */
-#define PIC32_PMMODE_INCM_NONE	0x0000	/* No increment/decrement */
-#define PIC32_PMMODE_INCM_INC	0x0800	/* Increment address */
-#define PIC32_PMMODE_INCM_DEC	0x1000	/* Decrement address */
-#define PIC32_PMMODE_INCM_SLAVE	0x1800	/* Slave auto-increment */
-#define PIC32_PMMODE_IRQM	0x6000	/* Interrupt request bitmask: */
-#define PIC32_PMMODE_IRQM_DIS	0x0000	/* No interrupt generated */
-#define PIC32_PMMODE_IRQM_END	0x2000	/* Interrupt at end of read/write cycle */
-#define PIC32_PMMODE_IRQM_A3	0x4000	/* Interrupt on address 3 */
-#define PIC32_PMMODE_BUSY	0x8000	/* Port is busy */
+#define PIC32_PMMODE_WAITE(x)   ((x)<<0) /* Wait states: data hold after RW strobe */
+#define PIC32_PMMODE_WAITM(x)   ((x)<<2) /* Wait states: data RW strobe */
+#define PIC32_PMMODE_WAITB(x)   ((x)<<6) /* Wait states: data setup to RW strobe */
+#define PIC32_PMMODE_MODE   0x0300  /* Mode select bitmask: */
+#define PIC32_PMMODE_MODE_SLAVE 0x0000  /* Legacy slave */
+#define PIC32_PMMODE_MODE_SLENH 0x0100  /* Enhanced slave */
+#define PIC32_PMMODE_MODE_MAST2 0x0200  /* Master mode 2 */
+#define PIC32_PMMODE_MODE_MAST1 0x0300  /* Master mode 1 */
+#define PIC32_PMMODE_MODE16 0x0400  /* 16-bit mode */
+#define PIC32_PMMODE_INCM   0x1800  /* Address increment mode bitmask: */
+#define PIC32_PMMODE_INCM_NONE  0x0000  /* No increment/decrement */
+#define PIC32_PMMODE_INCM_INC   0x0800  /* Increment address */
+#define PIC32_PMMODE_INCM_DEC   0x1000  /* Decrement address */
+#define PIC32_PMMODE_INCM_SLAVE 0x1800  /* Slave auto-increment */
+#define PIC32_PMMODE_IRQM   0x6000  /* Interrupt request bitmask: */
+#define PIC32_PMMODE_IRQM_DIS   0x0000  /* No interrupt generated */
+#define PIC32_PMMODE_IRQM_END   0x2000  /* Interrupt at end of read/write cycle */
+#define PIC32_PMMODE_IRQM_A3    0x4000  /* Interrupt on address 3 */
+#define PIC32_PMMODE_BUSY   0x8000  /* Port is busy */
 
 /*
  * PMP Address register.
  */
-#define PIC32_PMADDR_PADDR	0x3FFF /* Destination address */
-#define PIC32_PMADDR_CS1	0x4000 /* Chip select 1 is active */
-#define PIC32_PMADDR_CS2	0x8000 /* Chip select 2 is active */
+#define PIC32_PMADDR_PADDR  0x3FFF /* Destination address */
+#define PIC32_PMADDR_CS1    0x4000 /* Chip select 1 is active */
+#define PIC32_PMADDR_CS2    0x8000 /* Chip select 2 is active */
 
 /*
  * PMP status register (slave only).
  */
-#define PIC32_PMSTAT_OB0E	0x0001 /* Output buffer 0 empty */
-#define PIC32_PMSTAT_OB1E	0x0002 /* Output buffer 1 empty */
-#define PIC32_PMSTAT_OB2E	0x0004 /* Output buffer 2 empty */
-#define PIC32_PMSTAT_OB3E	0x0008 /* Output buffer 3 empty */
-#define PIC32_PMSTAT_OBUF	0x0040 /* Output buffer underflow */
-#define PIC32_PMSTAT_OBE	0x0080 /* Output buffer empty */
-#define PIC32_PMSTAT_IB0F	0x0100 /* Input buffer 0 full */
-#define PIC32_PMSTAT_IB1F	0x0200 /* Input buffer 1 full */
-#define PIC32_PMSTAT_IB2F	0x0400 /* Input buffer 2 full */
-#define PIC32_PMSTAT_IB3F	0x0800 /* Input buffer 3 full */
-#define PIC32_PMSTAT_IBOV	0x4000 /* Input buffer overflow */
-#define PIC32_PMSTAT_IBF	0x8000 /* Input buffer full */
+#define PIC32_PMSTAT_OB0E   0x0001 /* Output buffer 0 empty */
+#define PIC32_PMSTAT_OB1E   0x0002 /* Output buffer 1 empty */
+#define PIC32_PMSTAT_OB2E   0x0004 /* Output buffer 2 empty */
+#define PIC32_PMSTAT_OB3E   0x0008 /* Output buffer 3 empty */
+#define PIC32_PMSTAT_OBUF   0x0040 /* Output buffer underflow */
+#define PIC32_PMSTAT_OBE    0x0080 /* Output buffer empty */
+#define PIC32_PMSTAT_IB0F   0x0100 /* Input buffer 0 full */
+#define PIC32_PMSTAT_IB1F   0x0200 /* Input buffer 1 full */
+#define PIC32_PMSTAT_IB2F   0x0400 /* Input buffer 2 full */
+#define PIC32_PMSTAT_IB3F   0x0800 /* Input buffer 3 full */
+#define PIC32_PMSTAT_IBOV   0x4000 /* Input buffer overflow */
+#define PIC32_PMSTAT_IBF    0x8000 /* Input buffer full */
 
 /*--------------------------------------
  * UART registers.
  */
-#define U1MODE		PIC32_R (0x22000) /* Mode */
-#define U1MODECLR	PIC32_R (0x22004)
-#define U1MODESET	PIC32_R (0x22008)
-#define U1MODEINV	PIC32_R (0x2200C)
-#define U1STA		PIC32_R (0x22010) /* Status and control */
-#define U1STACLR	PIC32_R (0x22014)
-#define U1STASET	PIC32_R (0x22018)
-#define U1STAINV	PIC32_R (0x2201C)
-#define U1TXREG		PIC32_R (0x22020) /* Transmit */
-#define U1RXREG		PIC32_R (0x22030) /* Receive */
-#define U1BRG		PIC32_R (0x22040) /* Baud rate */
-#define U1BRGCLR	PIC32_R (0x22044)
-#define U1BRGSET	PIC32_R (0x22048)
-#define U1BRGINV	PIC32_R (0x2204C)
+#define U1MODE      PIC32_R (0x22000) /* Mode */
+#define U1MODECLR   PIC32_R (0x22004)
+#define U1MODESET   PIC32_R (0x22008)
+#define U1MODEINV   PIC32_R (0x2200C)
+#define U1STA       PIC32_R (0x22010) /* Status and control */
+#define U1STACLR    PIC32_R (0x22014)
+#define U1STASET    PIC32_R (0x22018)
+#define U1STAINV    PIC32_R (0x2201C)
+#define U1TXREG     PIC32_R (0x22020) /* Transmit */
+#define U1RXREG     PIC32_R (0x22030) /* Receive */
+#define U1BRG       PIC32_R (0x22040) /* Baud rate */
+#define U1BRGCLR    PIC32_R (0x22044)
+#define U1BRGSET    PIC32_R (0x22048)
+#define U1BRGINV    PIC32_R (0x2204C)
 
-#define U2MODE		PIC32_R (0x22200) /* Mode */
-#define U2MODECLR	PIC32_R (0x22204)
-#define U2MODESET	PIC32_R (0x22208)
-#define U2MODEINV	PIC32_R (0x2220C)
-#define U2STA		PIC32_R (0x22210) /* Status and control */
-#define U2STACLR	PIC32_R (0x22214)
-#define U2STASET	PIC32_R (0x22218)
-#define U2STAINV	PIC32_R (0x2221C)
-#define U2TXREG		PIC32_R (0x22220) /* Transmit */
-#define U2RXREG		PIC32_R (0x22230) /* Receive */
-#define U2BRG		PIC32_R (0x22240) /* Baud rate */
-#define U2BRGCLR	PIC32_R (0x22244)
-#define U2BRGSET	PIC32_R (0x22248)
-#define U2BRGINV	PIC32_R (0x2224C)
+#define U2MODE      PIC32_R (0x22200) /* Mode */
+#define U2MODECLR   PIC32_R (0x22204)
+#define U2MODESET   PIC32_R (0x22208)
+#define U2MODEINV   PIC32_R (0x2220C)
+#define U2STA       PIC32_R (0x22210) /* Status and control */
+#define U2STACLR    PIC32_R (0x22214)
+#define U2STASET    PIC32_R (0x22218)
+#define U2STAINV    PIC32_R (0x2221C)
+#define U2TXREG     PIC32_R (0x22220) /* Transmit */
+#define U2RXREG     PIC32_R (0x22230) /* Receive */
+#define U2BRG       PIC32_R (0x22240) /* Baud rate */
+#define U2BRGCLR    PIC32_R (0x22244)
+#define U2BRGSET    PIC32_R (0x22248)
+#define U2BRGINV    PIC32_R (0x2224C)
 
-#define U3MODE		PIC32_R (0x22400) /* Mode */
-#define U3MODECLR	PIC32_R (0x22404)
-#define U3MODESET	PIC32_R (0x22408)
-#define U3MODEINV	PIC32_R (0x2240C)
-#define U3STA		PIC32_R (0x22410) /* Status and control */
-#define U3STACLR	PIC32_R (0x22414)
-#define U3STASET	PIC32_R (0x22418)
-#define U3STAINV	PIC32_R (0x2241C)
-#define U3TXREG		PIC32_R (0x22420) /* Transmit */
-#define U3RXREG		PIC32_R (0x22430) /* Receive */
-#define U3BRG		PIC32_R (0x22440) /* Baud rate */
-#define U3BRGCLR	PIC32_R (0x22444)
-#define U3BRGSET	PIC32_R (0x22448)
-#define U3BRGINV	PIC32_R (0x2244C)
+#define U3MODE      PIC32_R (0x22400) /* Mode */
+#define U3MODECLR   PIC32_R (0x22404)
+#define U3MODESET   PIC32_R (0x22408)
+#define U3MODEINV   PIC32_R (0x2240C)
+#define U3STA       PIC32_R (0x22410) /* Status and control */
+#define U3STACLR    PIC32_R (0x22414)
+#define U3STASET    PIC32_R (0x22418)
+#define U3STAINV    PIC32_R (0x2241C)
+#define U3TXREG     PIC32_R (0x22420) /* Transmit */
+#define U3RXREG     PIC32_R (0x22430) /* Receive */
+#define U3BRG       PIC32_R (0x22440) /* Baud rate */
+#define U3BRGCLR    PIC32_R (0x22444)
+#define U3BRGSET    PIC32_R (0x22448)
+#define U3BRGINV    PIC32_R (0x2244C)
 
-#define U4MODE		PIC32_R (0x22600) /* Mode */
-#define U4MODECLR	PIC32_R (0x22604)
-#define U4MODESET	PIC32_R (0x22608)
-#define U4MODEINV	PIC32_R (0x2260C)
-#define U4STA		PIC32_R (0x22610) /* Status and control */
-#define U4STACLR	PIC32_R (0x22614)
-#define U4STASET	PIC32_R (0x22618)
-#define U4STAINV	PIC32_R (0x2261C)
-#define U4TXREG		PIC32_R (0x22620) /* Transmit */
-#define U4RXREG		PIC32_R (0x22630) /* Receive */
-#define U4BRG		PIC32_R (0x22640) /* Baud rate */
-#define U4BRGCLR	PIC32_R (0x22644)
-#define U4BRGSET	PIC32_R (0x22648)
-#define U4BRGINV	PIC32_R (0x2264C)
+#define U4MODE      PIC32_R (0x22600) /* Mode */
+#define U4MODECLR   PIC32_R (0x22604)
+#define U4MODESET   PIC32_R (0x22608)
+#define U4MODEINV   PIC32_R (0x2260C)
+#define U4STA       PIC32_R (0x22610) /* Status and control */
+#define U4STACLR    PIC32_R (0x22614)
+#define U4STASET    PIC32_R (0x22618)
+#define U4STAINV    PIC32_R (0x2261C)
+#define U4TXREG     PIC32_R (0x22620) /* Transmit */
+#define U4RXREG     PIC32_R (0x22630) /* Receive */
+#define U4BRG       PIC32_R (0x22640) /* Baud rate */
+#define U4BRGCLR    PIC32_R (0x22644)
+#define U4BRGSET    PIC32_R (0x22648)
+#define U4BRGINV    PIC32_R (0x2264C)
 
-#define U5MODE		PIC32_R (0x22800) /* Mode */
-#define U5MODECLR	PIC32_R (0x22804)
-#define U5MODESET	PIC32_R (0x22808)
-#define U5MODEINV	PIC32_R (0x2280C)
-#define U5STA		PIC32_R (0x22810) /* Status and control */
-#define U5STACLR	PIC32_R (0x22814)
-#define U5STASET	PIC32_R (0x22818)
-#define U5STAINV	PIC32_R (0x2281C)
-#define U5TXREG		PIC32_R (0x22820) /* Transmit */
-#define U5RXREG		PIC32_R (0x22830) /* Receive */
-#define U5BRG		PIC32_R (0x22840) /* Baud rate */
-#define U5BRGCLR	PIC32_R (0x22844)
-#define U5BRGSET	PIC32_R (0x22848)
-#define U5BRGINV	PIC32_R (0x2284C)
+#define U5MODE      PIC32_R (0x22800) /* Mode */
+#define U5MODECLR   PIC32_R (0x22804)
+#define U5MODESET   PIC32_R (0x22808)
+#define U5MODEINV   PIC32_R (0x2280C)
+#define U5STA       PIC32_R (0x22810) /* Status and control */
+#define U5STACLR    PIC32_R (0x22814)
+#define U5STASET    PIC32_R (0x22818)
+#define U5STAINV    PIC32_R (0x2281C)
+#define U5TXREG     PIC32_R (0x22820) /* Transmit */
+#define U5RXREG     PIC32_R (0x22830) /* Receive */
+#define U5BRG       PIC32_R (0x22840) /* Baud rate */
+#define U5BRGCLR    PIC32_R (0x22844)
+#define U5BRGSET    PIC32_R (0x22848)
+#define U5BRGINV    PIC32_R (0x2284C)
 
-#define U6MODE		PIC32_R (0x22A00) /* Mode */
-#define U6MODECLR	PIC32_R (0x22A04)
-#define U6MODESET	PIC32_R (0x22A08)
-#define U6MODEINV	PIC32_R (0x22A0C)
-#define U6STA		PIC32_R (0x22A10) /* Status and control */
-#define U6STACLR	PIC32_R (0x22A14)
-#define U6STASET	PIC32_R (0x22A18)
-#define U6STAINV	PIC32_R (0x22A1C)
-#define U6TXREG		PIC32_R (0x22A20) /* Transmit */
-#define U6RXREG		PIC32_R (0x22A30) /* Receive */
-#define U6BRG		PIC32_R (0x22A40) /* Baud rate */
-#define U6BRGCLR	PIC32_R (0x22A44)
-#define U6BRGSET	PIC32_R (0x22A48)
-#define U6BRGINV	PIC32_R (0x22A4C)
+#define U6MODE      PIC32_R (0x22A00) /* Mode */
+#define U6MODECLR   PIC32_R (0x22A04)
+#define U6MODESET   PIC32_R (0x22A08)
+#define U6MODEINV   PIC32_R (0x22A0C)
+#define U6STA       PIC32_R (0x22A10) /* Status and control */
+#define U6STACLR    PIC32_R (0x22A14)
+#define U6STASET    PIC32_R (0x22A18)
+#define U6STAINV    PIC32_R (0x22A1C)
+#define U6TXREG     PIC32_R (0x22A20) /* Transmit */
+#define U6RXREG     PIC32_R (0x22A30) /* Receive */
+#define U6BRG       PIC32_R (0x22A40) /* Baud rate */
+#define U6BRGCLR    PIC32_R (0x22A44)
+#define U6BRGSET    PIC32_R (0x22A48)
+#define U6BRGINV    PIC32_R (0x22A4C)
 
 /*
  * UART Mode register.
  */
-#define PIC32_UMODE_STSEL	0x0001	/* 2 Stop bits */
-#define PIC32_UMODE_PDSEL	0x0006	/* Bitmask: */
-#define PIC32_UMODE_PDSEL_8NPAR	0x0000	/* 8-bit data, no parity */
-#define PIC32_UMODE_PDSEL_8EVEN	0x0002	/* 8-bit data, even parity */
-#define PIC32_UMODE_PDSEL_8ODD	0x0004	/* 8-bit data, odd parity */
-#define PIC32_UMODE_PDSEL_9NPAR	0x0006	/* 9-bit data, no parity */
-#define PIC32_UMODE_BRGH	0x0008	/* High Baud Rate Enable */
-#define PIC32_UMODE_RXINV	0x0010	/* Receive Polarity Inversion */
-#define PIC32_UMODE_ABAUD	0x0020	/* Auto-Baud Enable */
-#define PIC32_UMODE_LPBACK	0x0040	/* UARTx Loopback Mode */
-#define PIC32_UMODE_WAKE	0x0080	/* Wake-up on start bit during Sleep Mode */
-#define PIC32_UMODE_UEN		0x0300	/* Bitmask: */
-#define PIC32_UMODE_UEN_RTS	0x0100	/* Using UxRTS pin */
-#define PIC32_UMODE_UEN_RTSCTS	0x0200	/* Using UxCTS and UxRTS pins */
-#define PIC32_UMODE_UEN_BCLK	0x0300	/* Using UxBCLK pin */
-#define PIC32_UMODE_RTSMD	0x0800	/* UxRTS Pin Simplex mode */
-#define PIC32_UMODE_IREN	0x1000	/* IrDA Encoder and Decoder Enable bit */
-#define PIC32_UMODE_SIDL	0x2000	/* Stop in Idle Mode */
-#define PIC32_UMODE_FRZ		0x4000	/* Freeze in Debug Exception Mode */
-#define PIC32_UMODE_ON		0x8000	/* UART Enable */
+#define PIC32_UMODE_STSEL   0x0001  /* 2 Stop bits */
+#define PIC32_UMODE_PDSEL   0x0006  /* Bitmask: */
+#define PIC32_UMODE_PDSEL_8NPAR 0x0000  /* 8-bit data, no parity */
+#define PIC32_UMODE_PDSEL_8EVEN 0x0002  /* 8-bit data, even parity */
+#define PIC32_UMODE_PDSEL_8ODD  0x0004  /* 8-bit data, odd parity */
+#define PIC32_UMODE_PDSEL_9NPAR 0x0006  /* 9-bit data, no parity */
+#define PIC32_UMODE_BRGH    0x0008  /* High Baud Rate Enable */
+#define PIC32_UMODE_RXINV   0x0010  /* Receive Polarity Inversion */
+#define PIC32_UMODE_ABAUD   0x0020  /* Auto-Baud Enable */
+#define PIC32_UMODE_LPBACK  0x0040  /* UARTx Loopback Mode */
+#define PIC32_UMODE_WAKE    0x0080  /* Wake-up on start bit during Sleep Mode */
+#define PIC32_UMODE_UEN     0x0300  /* Bitmask: */
+#define PIC32_UMODE_UEN_RTS 0x0100  /* Using UxRTS pin */
+#define PIC32_UMODE_UEN_RTSCTS  0x0200  /* Using UxCTS and UxRTS pins */
+#define PIC32_UMODE_UEN_BCLK    0x0300  /* Using UxBCLK pin */
+#define PIC32_UMODE_RTSMD   0x0800  /* UxRTS Pin Simplex mode */
+#define PIC32_UMODE_IREN    0x1000  /* IrDA Encoder and Decoder Enable bit */
+#define PIC32_UMODE_SIDL    0x2000  /* Stop in Idle Mode */
+#define PIC32_UMODE_FRZ     0x4000  /* Freeze in Debug Exception Mode */
+#define PIC32_UMODE_ON      0x8000  /* UART Enable */
 
 /*
  * UART Control and status register.
  */
-#define PIC32_USTA_URXDA	0x00000001 /* Receive Data Available (read-only) */
-#define PIC32_USTA_OERR		0x00000002 /* Receive Buffer Overrun */
-#define PIC32_USTA_FERR		0x00000004 /* Framing error detected (read-only) */
-#define PIC32_USTA_PERR		0x00000008 /* Parity error detected (read-only) */
-#define PIC32_USTA_RIDLE	0x00000010 /* Receiver is idle (read-only) */
-#define PIC32_USTA_ADDEN	0x00000020 /* Address Detect mode */
-#define PIC32_USTA_URXISEL	0x000000C0 /* Bitmask: receive interrupt is set when... */
-#define PIC32_USTA_URXISEL_NEMP	0x00000000 /* ...receive buffer is not empty */
-#define PIC32_USTA_URXISEL_HALF	0x00000040 /* ...receive buffer becomes 1/2 full */
-#define PIC32_USTA_URXISEL_3_4	0x00000080 /* ...receive buffer becomes 3/4 full */
-#define PIC32_USTA_TRMT		0x00000100 /* Transmit shift register is empty (read-only) */
-#define PIC32_USTA_UTXBF	0x00000200 /* Transmit buffer is full (read-only) */
-#define PIC32_USTA_UTXEN	0x00000400 /* Transmit Enable */
-#define PIC32_USTA_UTXBRK	0x00000800 /* Transmit Break */
-#define PIC32_USTA_URXEN	0x00001000 /* Receiver Enable */
-#define PIC32_USTA_UTXINV	0x00002000 /* Transmit Polarity Inversion */
-#define PIC32_USTA_UTXISEL	0x0000C000 /* Bitmask: TX interrupt is generated when... */
-#define PIC32_USTA_UTXISEL_1	0x00000000 /* ...the transmit buffer contains at least one empty space */
-#define PIC32_USTA_UTXISEL_ALL	0x00004000 /* ...all characters have been transmitted */
-#define PIC32_USTA_UTXISEL_EMP	0x00008000 /* ...the transmit buffer becomes empty */
-#define PIC32_USTA_ADDR		0x00FF0000 /* Automatic Address Mask */
-#define PIC32_USTA_ADM_EN	0x01000000 /* Automatic Address Detect */
+#define PIC32_USTA_URXDA    0x00000001 /* Receive Data Available (read-only) */
+#define PIC32_USTA_OERR     0x00000002 /* Receive Buffer Overrun */
+#define PIC32_USTA_FERR     0x00000004 /* Framing error detected (read-only) */
+#define PIC32_USTA_PERR     0x00000008 /* Parity error detected (read-only) */
+#define PIC32_USTA_RIDLE    0x00000010 /* Receiver is idle (read-only) */
+#define PIC32_USTA_ADDEN    0x00000020 /* Address Detect mode */
+#define PIC32_USTA_URXISEL  0x000000C0 /* Bitmask: receive interrupt is set when... */
+#define PIC32_USTA_URXISEL_NEMP 0x00000000 /* ...receive buffer is not empty */
+#define PIC32_USTA_URXISEL_HALF 0x00000040 /* ...receive buffer becomes 1/2 full */
+#define PIC32_USTA_URXISEL_3_4  0x00000080 /* ...receive buffer becomes 3/4 full */
+#define PIC32_USTA_TRMT     0x00000100 /* Transmit shift register is empty (read-only) */
+#define PIC32_USTA_UTXBF    0x00000200 /* Transmit buffer is full (read-only) */
+#define PIC32_USTA_UTXEN    0x00000400 /* Transmit Enable */
+#define PIC32_USTA_UTXBRK   0x00000800 /* Transmit Break */
+#define PIC32_USTA_URXEN    0x00001000 /* Receiver Enable */
+#define PIC32_USTA_UTXINV   0x00002000 /* Transmit Polarity Inversion */
+#define PIC32_USTA_UTXISEL  0x0000C000 /* Bitmask: TX interrupt is generated when... */
+#define PIC32_USTA_UTXISEL_1    0x00000000 /* ...the transmit buffer contains at least one empty space */
+#define PIC32_USTA_UTXISEL_ALL  0x00004000 /* ...all characters have been transmitted */
+#define PIC32_USTA_UTXISEL_EMP  0x00008000 /* ...the transmit buffer becomes empty */
+#define PIC32_USTA_ADDR     0x00FF0000 /* Automatic Address Mask */
+#define PIC32_USTA_ADM_EN   0x01000000 /* Automatic Address Detect */
 
 /*
  * Compute the 16-bit baud rate divisor, given
  * the bus frequency and baud rate.
  * Round to the nearest integer.
  */
-#define PIC32_BRG_BAUD(fr,bd)	((((fr)/8 + (bd)) / (bd) / 2) - 1)
+#define PIC32_BRG_BAUD(fr,bd)   ((((fr)/8 + (bd)) / (bd) / 2) - 1)
 
 /*--------------------------------------
  * Peripheral port select registers.
@@ -1089,13 +1089,13 @@
  * Prefetch cache controller registers.
  */
 #define PRECON          PIC32_R (0xe0000)       /* Prefetch cache control */
-#define PRECONCLR	PIC32_R (0xe0004)
-#define PRECONSET	PIC32_R (0xe0008)
-#define PRECONINV	PIC32_R (0xe000C)
+#define PRECONCLR   PIC32_R (0xe0004)
+#define PRECONSET   PIC32_R (0xe0008)
+#define PRECONINV   PIC32_R (0xe000C)
 #define PRESTAT         PIC32_R (0xe0010)       /* Prefetch status */
-#define PRESTATCLR	PIC32_R (0xe0014)
-#define PRESTATSET	PIC32_R (0xe0018)
-#define PRESTATINV	PIC32_R (0xe001C)
+#define PRESTATCLR  PIC32_R (0xe0014)
+#define PRESTATSET  PIC32_R (0xe0018)
+#define PRESTATINV  PIC32_R (0xe001C)
 // TODO: other prefetch registers
 
 /*--------------------------------------
@@ -1104,20 +1104,20 @@
 #define CFGCON          PIC32_R (0x0000)
 #define DEVID           PIC32_R (0x0020)
 #define SYSKEY          PIC32_R (0x0030)
-#define CFGEBIA	        PIC32_R (0x00c0)
-#define CFGEBIACLR	PIC32_R (0x00c4)
-#define CFGEBIASET	PIC32_R (0x00c8)
-#define CFGEBIAINV	PIC32_R (0x00cc)
+#define CFGEBIA         PIC32_R (0x00c0)
+#define CFGEBIACLR  PIC32_R (0x00c4)
+#define CFGEBIASET  PIC32_R (0x00c8)
+#define CFGEBIAINV  PIC32_R (0x00cc)
 #define CFGEBIC         PIC32_R (0x00d0)
-#define CFGEBICCLR	PIC32_R (0x00d4)
-#define CFGEBICSET	PIC32_R (0x00d8)
-#define CFGEBICINV	PIC32_R (0x00dc)
+#define CFGEBICCLR  PIC32_R (0x00d4)
+#define CFGEBICSET  PIC32_R (0x00d8)
+#define CFGEBICINV  PIC32_R (0x00dc)
 #define CFGPG           PIC32_R (0x00e0)
 
 #define OSCCON          PIC32_R (0x1200)    /* Oscillator Control */
 #define OSCTUN          PIC32_R (0x1210)
 #define SPLLCON         PIC32_R (0x1220)
-#define RCON	        PIC32_R (0x1240)
+#define RCON            PIC32_R (0x1240)
 #define RSWRST          PIC32_R (0x1250)
 #define RNMICON         PIC32_R (0x1260)
 #define PWRCON          PIC32_R (0x1270)
@@ -1140,22 +1140,22 @@
 /*
  * Configuration Control register.
  */
-#define PIC32_CFGCON_DMAPRI	0x02000000 /* DMA gets High Priority access to SRAM */
-#define PIC32_CFGCON_CPUPRI	0x01000000 /* CPU gets High Priority access to SRAM */
-#define PIC32_CFGCON_ICACLK	0x00020000 /* Input Capture alternate clock selection */
-#define PIC32_CFGCON_OCACLK	0x00010000 /* Output Compare alternate clock selection */
-#define PIC32_CFGCON_IOLOCK	0x00002000 /* Peripheral pin select lock */
-#define PIC32_CFGCON_PMDLOCK	0x00001000 /* Peripheral module disable */
-#define PIC32_CFGCON_PGLOCK	0x00000800 /* Permission group lock */
-#define PIC32_CFGCON_USBSSEN	0x00000100 /* USB suspend sleep enable */
-#define PIC32_CFGCON_ECC_MASK	0x00000030 /* Flash ECC Configuration */
-#define PIC32_CFGCON_ECC_DISWR	0x00000030 /* ECC disabled, ECCCON<1:0> writable */
-#define PIC32_CFGCON_ECC_DISRO	0x00000020 /* ECC disabled, ECCCON<1:0> locked */
-#define PIC32_CFGCON_ECC_DYN	0x00000010 /* Dynamic Flash ECC is enabled */
-#define PIC32_CFGCON_ECC_EN	0x00000000 /* Flash ECC is enabled */
-#define PIC32_CFGCON_JTAGEN	0x00000008 /* JTAG port enable */
-#define PIC32_CFGCON_TROEN	0x00000004 /* Trace output enable */
-#define PIC32_CFGCON_TDOEN	0x00000001 /* 2-wire JTAG protocol uses TDO */
+#define PIC32_CFGCON_DMAPRI 0x02000000 /* DMA gets High Priority access to SRAM */
+#define PIC32_CFGCON_CPUPRI 0x01000000 /* CPU gets High Priority access to SRAM */
+#define PIC32_CFGCON_ICACLK 0x00020000 /* Input Capture alternate clock selection */
+#define PIC32_CFGCON_OCACLK 0x00010000 /* Output Compare alternate clock selection */
+#define PIC32_CFGCON_IOLOCK 0x00002000 /* Peripheral pin select lock */
+#define PIC32_CFGCON_PMDLOCK    0x00001000 /* Peripheral module disable */
+#define PIC32_CFGCON_PGLOCK 0x00000800 /* Permission group lock */
+#define PIC32_CFGCON_USBSSEN    0x00000100 /* USB suspend sleep enable */
+#define PIC32_CFGCON_ECC_MASK   0x00000030 /* Flash ECC Configuration */
+#define PIC32_CFGCON_ECC_DISWR  0x00000030 /* ECC disabled, ECCCON<1:0> writable */
+#define PIC32_CFGCON_ECC_DISRO  0x00000020 /* ECC disabled, ECCCON<1:0> locked */
+#define PIC32_CFGCON_ECC_DYN    0x00000010 /* Dynamic Flash ECC is enabled */
+#define PIC32_CFGCON_ECC_EN 0x00000000 /* Flash ECC is enabled */
+#define PIC32_CFGCON_JTAGEN 0x00000008 /* JTAG port enable */
+#define PIC32_CFGCON_TROEN  0x00000004 /* Trace output enable */
+#define PIC32_CFGCON_TDOEN  0x00000001 /* 2-wire JTAG protocol uses TDO */
 
 /*--------------------------------------
  * A/D Converter registers.
@@ -1251,188 +1251,188 @@
 /*--------------------------------------
  * SPI registers.
  */
-#define SPI1CON		PIC32_R (0x21000) /* Control */
-#define SPI1CONCLR	PIC32_R (0x21004)
-#define SPI1CONSET	PIC32_R (0x21008)
-#define SPI1CONINV	PIC32_R (0x2100c)
-#define SPI1STAT	PIC32_R (0x21010) /* Status */
-#define SPI1STATCLR	PIC32_R (0x21014)
-#define SPI1STATSET	PIC32_R (0x21018)
-#define SPI1STATINV	PIC32_R (0x2101c)
-#define SPI1BUF		PIC32_R (0x21020) /* Transmit and receive buffer */
-#define SPI1BRG		PIC32_R (0x21030) /* Baud rate generator */
-#define SPI1BRGCLR	PIC32_R (0x21034)
-#define SPI1BRGSET	PIC32_R (0x21038)
-#define SPI1BRGINV	PIC32_R (0x2103c)
-#define SPI1CON2	PIC32_R (0x21040) /* Control 2 */
-#define SPI1CON2CLR	PIC32_R (0x21044)
-#define SPI1CON2SET	PIC32_R (0x21048)
-#define SPI1CON2INV	PIC32_R (0x2104c)
+#define SPI1CON     PIC32_R (0x21000) /* Control */
+#define SPI1CONCLR  PIC32_R (0x21004)
+#define SPI1CONSET  PIC32_R (0x21008)
+#define SPI1CONINV  PIC32_R (0x2100c)
+#define SPI1STAT    PIC32_R (0x21010) /* Status */
+#define SPI1STATCLR PIC32_R (0x21014)
+#define SPI1STATSET PIC32_R (0x21018)
+#define SPI1STATINV PIC32_R (0x2101c)
+#define SPI1BUF     PIC32_R (0x21020) /* Transmit and receive buffer */
+#define SPI1BRG     PIC32_R (0x21030) /* Baud rate generator */
+#define SPI1BRGCLR  PIC32_R (0x21034)
+#define SPI1BRGSET  PIC32_R (0x21038)
+#define SPI1BRGINV  PIC32_R (0x2103c)
+#define SPI1CON2    PIC32_R (0x21040) /* Control 2 */
+#define SPI1CON2CLR PIC32_R (0x21044)
+#define SPI1CON2SET PIC32_R (0x21048)
+#define SPI1CON2INV PIC32_R (0x2104c)
 
-#define SPI2CON		PIC32_R (0x21200) /* Control */
-#define SPI2CONCLR	PIC32_R (0x21204)
-#define SPI2CONSET	PIC32_R (0x21208)
-#define SPI2CONINV	PIC32_R (0x2120c)
-#define SPI2STAT	PIC32_R (0x21210) /* Status */
-#define SPI2STATCLR	PIC32_R (0x21214)
-#define SPI2STATSET	PIC32_R (0x21218)
-#define SPI2STATINV	PIC32_R (0x2121c)
-#define SPI2BUF		PIC32_R (0x21220) /* Transmit and receive buffer */
-#define SPI2BRG		PIC32_R (0x21230) /* Baud rate generator */
-#define SPI2BRGCLR	PIC32_R (0x21234)
-#define SPI2BRGSET	PIC32_R (0x21238)
-#define SPI2BRGINV	PIC32_R (0x2123c)
-#define SPI2CON2	PIC32_R (0x21240) /* Control 2 */
-#define SPI2CON2CLR	PIC32_R (0x21244)
-#define SPI2CON2SET	PIC32_R (0x21248)
-#define SPI2CON2INV	PIC32_R (0x2124c)
+#define SPI2CON     PIC32_R (0x21200) /* Control */
+#define SPI2CONCLR  PIC32_R (0x21204)
+#define SPI2CONSET  PIC32_R (0x21208)
+#define SPI2CONINV  PIC32_R (0x2120c)
+#define SPI2STAT    PIC32_R (0x21210) /* Status */
+#define SPI2STATCLR PIC32_R (0x21214)
+#define SPI2STATSET PIC32_R (0x21218)
+#define SPI2STATINV PIC32_R (0x2121c)
+#define SPI2BUF     PIC32_R (0x21220) /* Transmit and receive buffer */
+#define SPI2BRG     PIC32_R (0x21230) /* Baud rate generator */
+#define SPI2BRGCLR  PIC32_R (0x21234)
+#define SPI2BRGSET  PIC32_R (0x21238)
+#define SPI2BRGINV  PIC32_R (0x2123c)
+#define SPI2CON2    PIC32_R (0x21240) /* Control 2 */
+#define SPI2CON2CLR PIC32_R (0x21244)
+#define SPI2CON2SET PIC32_R (0x21248)
+#define SPI2CON2INV PIC32_R (0x2124c)
 
-#define SPI3CON		PIC32_R (0x21400) /* Control */
-#define SPI3CONCLR	PIC32_R (0x21404)
-#define SPI3CONSET	PIC32_R (0x21408)
-#define SPI3CONINV	PIC32_R (0x2140c)
-#define SPI3STAT	PIC32_R (0x21410) /* Status */
-#define SPI3STATCLR	PIC32_R (0x21414)
-#define SPI3STATSET	PIC32_R (0x21418)
-#define SPI3STATINV	PIC32_R (0x2141c)
-#define SPI3BUF		PIC32_R (0x21420) /* Transmit and receive buffer */
-#define SPI3BRG		PIC32_R (0x21430) /* Baud rate generator */
-#define SPI3BRGCLR	PIC32_R (0x21434)
-#define SPI3BRGSET	PIC32_R (0x21438)
-#define SPI3BRGINV	PIC32_R (0x2143c)
-#define SPI3CON2	PIC32_R (0x21440) /* Control 2 */
-#define SPI3CON2CLR	PIC32_R (0x21444)
-#define SPI3CON2SET	PIC32_R (0x21448)
-#define SPI3CON2INV	PIC32_R (0x2144c)
+#define SPI3CON     PIC32_R (0x21400) /* Control */
+#define SPI3CONCLR  PIC32_R (0x21404)
+#define SPI3CONSET  PIC32_R (0x21408)
+#define SPI3CONINV  PIC32_R (0x2140c)
+#define SPI3STAT    PIC32_R (0x21410) /* Status */
+#define SPI3STATCLR PIC32_R (0x21414)
+#define SPI3STATSET PIC32_R (0x21418)
+#define SPI3STATINV PIC32_R (0x2141c)
+#define SPI3BUF     PIC32_R (0x21420) /* Transmit and receive buffer */
+#define SPI3BRG     PIC32_R (0x21430) /* Baud rate generator */
+#define SPI3BRGCLR  PIC32_R (0x21434)
+#define SPI3BRGSET  PIC32_R (0x21438)
+#define SPI3BRGINV  PIC32_R (0x2143c)
+#define SPI3CON2    PIC32_R (0x21440) /* Control 2 */
+#define SPI3CON2CLR PIC32_R (0x21444)
+#define SPI3CON2SET PIC32_R (0x21448)
+#define SPI3CON2INV PIC32_R (0x2144c)
 
-#define SPI4CON		PIC32_R (0x21600) /* Control */
-#define SPI4CONCLR	PIC32_R (0x21604)
-#define SPI4CONSET	PIC32_R (0x21608)
-#define SPI4CONINV	PIC32_R (0x2160c)
-#define SPI4STAT	PIC32_R (0x21610) /* Status */
-#define SPI4STATCLR	PIC32_R (0x21614)
-#define SPI4STATSET	PIC32_R (0x21618)
-#define SPI4STATINV	PIC32_R (0x2161c)
-#define SPI4BUF		PIC32_R (0x21620) /* Transmit and receive buffer */
-#define SPI4BRG		PIC32_R (0x21630) /* Baud rate generator */
-#define SPI4BRGCLR	PIC32_R (0x21634)
-#define SPI4BRGSET	PIC32_R (0x21638)
-#define SPI4BRGINV	PIC32_R (0x2163c)
-#define SPI4CON2	PIC32_R (0x21640) /* Control 2 */
-#define SPI4CON2CLR	PIC32_R (0x21644)
-#define SPI4CON2SET	PIC32_R (0x21648)
-#define SPI4CON2INV	PIC32_R (0x2164c)
+#define SPI4CON     PIC32_R (0x21600) /* Control */
+#define SPI4CONCLR  PIC32_R (0x21604)
+#define SPI4CONSET  PIC32_R (0x21608)
+#define SPI4CONINV  PIC32_R (0x2160c)
+#define SPI4STAT    PIC32_R (0x21610) /* Status */
+#define SPI4STATCLR PIC32_R (0x21614)
+#define SPI4STATSET PIC32_R (0x21618)
+#define SPI4STATINV PIC32_R (0x2161c)
+#define SPI4BUF     PIC32_R (0x21620) /* Transmit and receive buffer */
+#define SPI4BRG     PIC32_R (0x21630) /* Baud rate generator */
+#define SPI4BRGCLR  PIC32_R (0x21634)
+#define SPI4BRGSET  PIC32_R (0x21638)
+#define SPI4BRGINV  PIC32_R (0x2163c)
+#define SPI4CON2    PIC32_R (0x21640) /* Control 2 */
+#define SPI4CON2CLR PIC32_R (0x21644)
+#define SPI4CON2SET PIC32_R (0x21648)
+#define SPI4CON2INV PIC32_R (0x2164c)
 
-#define SPI5CON		PIC32_R (0x21800) /* Control */
-#define SPI5CONCLR	PIC32_R (0x21804)
-#define SPI5CONSET	PIC32_R (0x21808)
-#define SPI5CONINV	PIC32_R (0x2180c)
-#define SPI5STAT	PIC32_R (0x21810) /* Status */
-#define SPI5STATCLR	PIC32_R (0x21814)
-#define SPI5STATSET	PIC32_R (0x21818)
-#define SPI5STATINV	PIC32_R (0x2181c)
-#define SPI5BUF		PIC32_R (0x21820) /* Transmit and receive buffer */
-#define SPI5BRG		PIC32_R (0x21830) /* Baud rate generator */
-#define SPI5BRGCLR	PIC32_R (0x21834)
-#define SPI5BRGSET	PIC32_R (0x21838)
-#define SPI5BRGINV	PIC32_R (0x2183c)
-#define SPI5CON2	PIC32_R (0x21840) /* Control 2 */
-#define SPI5CON2CLR	PIC32_R (0x21844)
-#define SPI5CON2SET	PIC32_R (0x21848)
-#define SPI5CON2INV	PIC32_R (0x2184c)
+#define SPI5CON     PIC32_R (0x21800) /* Control */
+#define SPI5CONCLR  PIC32_R (0x21804)
+#define SPI5CONSET  PIC32_R (0x21808)
+#define SPI5CONINV  PIC32_R (0x2180c)
+#define SPI5STAT    PIC32_R (0x21810) /* Status */
+#define SPI5STATCLR PIC32_R (0x21814)
+#define SPI5STATSET PIC32_R (0x21818)
+#define SPI5STATINV PIC32_R (0x2181c)
+#define SPI5BUF     PIC32_R (0x21820) /* Transmit and receive buffer */
+#define SPI5BRG     PIC32_R (0x21830) /* Baud rate generator */
+#define SPI5BRGCLR  PIC32_R (0x21834)
+#define SPI5BRGSET  PIC32_R (0x21838)
+#define SPI5BRGINV  PIC32_R (0x2183c)
+#define SPI5CON2    PIC32_R (0x21840) /* Control 2 */
+#define SPI5CON2CLR PIC32_R (0x21844)
+#define SPI5CON2SET PIC32_R (0x21848)
+#define SPI5CON2INV PIC32_R (0x2184c)
 
-#define SPI6CON		PIC32_R (0x21a00) /* Control */
-#define SPI6CONCLR	PIC32_R (0x21a04)
-#define SPI6CONSET	PIC32_R (0x21a08)
-#define SPI6CONINV	PIC32_R (0x21a0c)
-#define SPI6STAT	PIC32_R (0x21a10) /* Status */
-#define SPI6STATCLR	PIC32_R (0x21a14)
-#define SPI6STATSET	PIC32_R (0x21a18)
-#define SPI6STATINV	PIC32_R (0x21a1c)
-#define SPI6BUF		PIC32_R (0x21a20) /* Transmit and receive buffer */
-#define SPI6BRG		PIC32_R (0x21a30) /* Baud rate generator */
-#define SPI6BRGCLR	PIC32_R (0x21a34)
-#define SPI6BRGSET	PIC32_R (0x21a38)
-#define SPI6BRGINV	PIC32_R (0x21a3c)
-#define SPI6CON2	PIC32_R (0x21a40) /* Control 2 */
-#define SPI6CON2CLR	PIC32_R (0x21a44)
-#define SPI6CON2SET	PIC32_R (0x21a48)
-#define SPI6CON2INV	PIC32_R (0x21a4c)
+#define SPI6CON     PIC32_R (0x21a00) /* Control */
+#define SPI6CONCLR  PIC32_R (0x21a04)
+#define SPI6CONSET  PIC32_R (0x21a08)
+#define SPI6CONINV  PIC32_R (0x21a0c)
+#define SPI6STAT    PIC32_R (0x21a10) /* Status */
+#define SPI6STATCLR PIC32_R (0x21a14)
+#define SPI6STATSET PIC32_R (0x21a18)
+#define SPI6STATINV PIC32_R (0x21a1c)
+#define SPI6BUF     PIC32_R (0x21a20) /* Transmit and receive buffer */
+#define SPI6BRG     PIC32_R (0x21a30) /* Baud rate generator */
+#define SPI6BRGCLR  PIC32_R (0x21a34)
+#define SPI6BRGSET  PIC32_R (0x21a38)
+#define SPI6BRGINV  PIC32_R (0x21a3c)
+#define SPI6CON2    PIC32_R (0x21a40) /* Control 2 */
+#define SPI6CON2CLR PIC32_R (0x21a44)
+#define SPI6CON2SET PIC32_R (0x21a48)
+#define SPI6CON2INV PIC32_R (0x21a4c)
 
 /*
  * SPI Control register.
  */
-#define PIC32_SPICON_MSTEN	0x00000020	/* Master mode */
-#define PIC32_SPICON_CKP	0x00000040      /* Idle clock is high level */
-#define PIC32_SPICON_SSEN	0x00000080      /* Slave mode: SSx pin enable */
-#define PIC32_SPICON_CKE	0x00000100      /* Output data changes on
-						 * transition from active clock
-						 * state to Idle clock state */
-#define PIC32_SPICON_SMP	0x00000200      /* Master mode: input data sampled
-						 * at end of data output time. */
-#define PIC32_SPICON_MODE16	0x00000400      /* 16-bit data width */
-#define PIC32_SPICON_MODE32	0x00000800      /* 32-bit data width */
-#define PIC32_SPICON_DISSDO	0x00001000      /* SDOx pin is not used */
-#define PIC32_SPICON_SIDL	0x00002000      /* Stop in Idle mode */
-#define PIC32_SPICON_FRZ	0x00004000      /* Freeze in Debug mode */
-#define PIC32_SPICON_ON		0x00008000      /* SPI Peripheral is enabled */
-#define PIC32_SPICON_ENHBUF	0x00010000      /* Enhanced buffer enable */
-#define PIC32_SPICON_SPIFE	0x00020000      /* Frame synchronization pulse
-						 * coincides with the first bit clock */
-#define PIC32_SPICON_FRMPOL	0x20000000      /* Frame pulse is active-high */
-#define PIC32_SPICON_FRMSYNC	0x40000000      /* Frame sync pulse input (Slave mode) */
-#define PIC32_SPICON_FRMEN	0x80000000      /* Framed SPI support */
+#define PIC32_SPICON_MSTEN  0x00000020  /* Master mode */
+#define PIC32_SPICON_CKP    0x00000040      /* Idle clock is high level */
+#define PIC32_SPICON_SSEN   0x00000080      /* Slave mode: SSx pin enable */
+#define PIC32_SPICON_CKE    0x00000100      /* Output data changes on
+                         * transition from active clock
+                         * state to Idle clock state */
+#define PIC32_SPICON_SMP    0x00000200      /* Master mode: input data sampled
+                         * at end of data output time. */
+#define PIC32_SPICON_MODE16 0x00000400      /* 16-bit data width */
+#define PIC32_SPICON_MODE32 0x00000800      /* 32-bit data width */
+#define PIC32_SPICON_DISSDO 0x00001000      /* SDOx pin is not used */
+#define PIC32_SPICON_SIDL   0x00002000      /* Stop in Idle mode */
+#define PIC32_SPICON_FRZ    0x00004000      /* Freeze in Debug mode */
+#define PIC32_SPICON_ON     0x00008000      /* SPI Peripheral is enabled */
+#define PIC32_SPICON_ENHBUF 0x00010000      /* Enhanced buffer enable */
+#define PIC32_SPICON_SPIFE  0x00020000      /* Frame synchronization pulse
+                         * coincides with the first bit clock */
+#define PIC32_SPICON_FRMPOL 0x20000000      /* Frame pulse is active-high */
+#define PIC32_SPICON_FRMSYNC    0x40000000      /* Frame sync pulse input (Slave mode) */
+#define PIC32_SPICON_FRMEN  0x80000000      /* Framed SPI support */
 
 /*
  * SPI Status register.
  */
-#define PIC32_SPISTAT_SPIRBF	0x00000001      /* Receive buffer is full */
-#define PIC32_SPISTAT_SPITBF	0x00000002      /* Transmit buffer is full */
-#define PIC32_SPISTAT_SPITBE	0x00000008      /* Transmit buffer is empty */
+#define PIC32_SPISTAT_SPIRBF    0x00000001      /* Receive buffer is full */
+#define PIC32_SPISTAT_SPITBF    0x00000002      /* Transmit buffer is full */
+#define PIC32_SPISTAT_SPITBE    0x00000008      /* Transmit buffer is empty */
 #define PIC32_SPISTAT_SPIRBE    0x00000020      /* Receive buffer is empty */
-#define PIC32_SPISTAT_SPIROV	0x00000040      /* Receive overflow flag */
-#define PIC32_SPISTAT_SPIBUSY	0x00000800      /* SPI is busy */
+#define PIC32_SPISTAT_SPIROV    0x00000040      /* Receive overflow flag */
+#define PIC32_SPISTAT_SPIBUSY   0x00000800      /* SPI is busy */
 
 /*--------------------------------------
  * Interrupt controller registers.
  */
-#define INTCON		PIC32_R (0x10000)	/* Interrupt Control */
-#define INTCONCLR	PIC32_R (0x10004)
-#define INTCONSET	PIC32_R (0x10008)
-#define INTCONINV	PIC32_R (0x1000C)
-#define PRISS		PIC32_R (0x10010)	/* Priority Shadow Select */
-#define PRISSCLR	PIC32_R (0x10014)
-#define PRISSSET	PIC32_R (0x10018)
-#define PRISSINV	PIC32_R (0x1001C)
-#define INTSTAT		PIC32_R (0x10020)	/* Interrupt Status */
-#define IPTMR		PIC32_R (0x10030)	/* Temporal Proximity Timer */
-#define IPTMRCLR	PIC32_R (0x10034)
-#define IPTMRSET	PIC32_R (0x10038)
-#define IPTMRINV	PIC32_R (0x1003C)
-#define IFS(n)		PIC32_R (0x10040+((n)<<4)) /* IFS(0..5) - Interrupt Flag Status */
-#define IFSCLR(n)	PIC32_R (0x10044+((n)<<4))
-#define IFSSET(n)	PIC32_R (0x10048+((n)<<4))
-#define IFSINV(n)	PIC32_R (0x1004C+((n)<<4))
+#define INTCON      PIC32_R (0x10000)   /* Interrupt Control */
+#define INTCONCLR   PIC32_R (0x10004)
+#define INTCONSET   PIC32_R (0x10008)
+#define INTCONINV   PIC32_R (0x1000C)
+#define PRISS       PIC32_R (0x10010)   /* Priority Shadow Select */
+#define PRISSCLR    PIC32_R (0x10014)
+#define PRISSSET    PIC32_R (0x10018)
+#define PRISSINV    PIC32_R (0x1001C)
+#define INTSTAT     PIC32_R (0x10020)   /* Interrupt Status */
+#define IPTMR       PIC32_R (0x10030)   /* Temporal Proximity Timer */
+#define IPTMRCLR    PIC32_R (0x10034)
+#define IPTMRSET    PIC32_R (0x10038)
+#define IPTMRINV    PIC32_R (0x1003C)
+#define IFS(n)      PIC32_R (0x10040+((n)<<4)) /* IFS(0..5) - Interrupt Flag Status */
+#define IFSCLR(n)   PIC32_R (0x10044+((n)<<4))
+#define IFSSET(n)   PIC32_R (0x10048+((n)<<4))
+#define IFSINV(n)   PIC32_R (0x1004C+((n)<<4))
 #define IFS0            IFS(0)
 #define IFS1            IFS(1)
 #define IFS2            IFS(2)
 #define IFS3            IFS(3)
 #define IFS4            IFS(4)
 #define IFS5            IFS(5)
-#define IEC(n)		PIC32_R (0x100c0+((n)<<4)) /* IEC(0..5) - Interrupt Enable Control */
-#define IECCLR(n)	PIC32_R (0x100c4+((n)<<4))
-#define IECSET(n)	PIC32_R (0x100c8+((n)<<4))
-#define IECINV(n)	PIC32_R (0x100cC+((n)<<4))
+#define IEC(n)      PIC32_R (0x100c0+((n)<<4)) /* IEC(0..5) - Interrupt Enable Control */
+#define IECCLR(n)   PIC32_R (0x100c4+((n)<<4))
+#define IECSET(n)   PIC32_R (0x100c8+((n)<<4))
+#define IECINV(n)   PIC32_R (0x100cC+((n)<<4))
 #define IEC0            IEC(0)
 #define IEC1            IEC(1)
 #define IEC2            IEC(2)
 #define IEC3            IEC(3)
 #define IEC4            IEC(4)
 #define IEC5            IEC(5)
-#define IPC(n)		PIC32_R (0x10140+((n)<<4)) /* IPC(0..47) - Interrupt Priority Control */
-#define IPCCLR(n)	PIC32_R (0x10144+((n)<<4))
-#define IPCSET(n)	PIC32_R (0x10148+((n)<<4))
-#define IPCINV(n)	PIC32_R (0x1014C+((n)<<4))
+#define IPC(n)      PIC32_R (0x10140+((n)<<4)) /* IPC(0..47) - Interrupt Priority Control */
+#define IPCCLR(n)   PIC32_R (0x10144+((n)<<4))
+#define IPCSET(n)   PIC32_R (0x10148+((n)<<4))
+#define IPCINV(n)   PIC32_R (0x1014C+((n)<<4))
 #define IPC0            IPC(0)
 #define IPC1            IPC(1)
 #define IPC2            IPC(2)
@@ -1481,39 +1481,39 @@
 #define IPC45           IPC(45)
 #define IPC46           IPC(46)
 #define IPC47           IPC(47)
-#define OFF(n)		PIC32_R (0x10540+((n)<<2)) /* OFF(0..190) - Interrupt Vector Address Offset */
+#define OFF(n)      PIC32_R (0x10540+((n)<<2)) /* OFF(0..190) - Interrupt Vector Address Offset */
 
 /*
  * Interrupt Control register.
  */
-#define PIC32_INTCON_INT0EP	0x00000001  /* External interrupt 0 polarity rising edge */
-#define PIC32_INTCON_INT1EP	0x00000002  /* External interrupt 1 polarity rising edge */
-#define PIC32_INTCON_INT2EP	0x00000004  /* External interrupt 2 polarity rising edge */
-#define PIC32_INTCON_INT3EP	0x00000008  /* External interrupt 3 polarity rising edge */
-#define PIC32_INTCON_INT4EP	0x00000010  /* External interrupt 4 polarity rising edge */
-#define PIC32_INTCON_TPC(x)	((x)<<8)    /* Temporal proximity group priority */
-#define PIC32_INTCON_MVEC	0x00001000  /* Multi-vectored mode */
-#define PIC32_INTCON_SS0	0x00010000  /* Single vector has a shadow register set */
-#define PIC32_INTCON_VS(x)	((x)<<16)   /* Temporal proximity group priority */
+#define PIC32_INTCON_INT0EP 0x00000001  /* External interrupt 0 polarity rising edge */
+#define PIC32_INTCON_INT1EP 0x00000002  /* External interrupt 1 polarity rising edge */
+#define PIC32_INTCON_INT2EP 0x00000004  /* External interrupt 2 polarity rising edge */
+#define PIC32_INTCON_INT3EP 0x00000008  /* External interrupt 3 polarity rising edge */
+#define PIC32_INTCON_INT4EP 0x00000010  /* External interrupt 4 polarity rising edge */
+#define PIC32_INTCON_TPC(x) ((x)<<8)    /* Temporal proximity group priority */
+#define PIC32_INTCON_MVEC   0x00001000  /* Multi-vectored mode */
+#define PIC32_INTCON_SS0    0x00010000  /* Single vector has a shadow register set */
+#define PIC32_INTCON_VS(x)  ((x)<<16)   /* Temporal proximity group priority */
 
 /*
  * Interrupt Status register.
  */
-#define PIC32_INTSTAT_VEC(s)	((s) & 0x3f)	/* Interrupt vector */
-#define PIC32_INTSTAT_SRIPL(s)	((s) >> 8 & 7)	/* Requested priority level */
+#define PIC32_INTSTAT_VEC(s)    ((s) & 0x3f)    /* Interrupt vector */
+#define PIC32_INTSTAT_SRIPL(s)  ((s) >> 8 & 7)  /* Requested priority level */
 #define PIC32_INTSTAT_SRIPL_MASK 0x0700
 
 /*
  * Interrupt Prority Control register.
  */
-#define PIC32_IPC_IS0(x)	(x)		/* Interrupt 0 subpriority */
-#define PIC32_IPC_IP0(x)	((x)<<2)	/* Interrupt 0 priority */
-#define PIC32_IPC_IS1(x)	((x)<<8)	/* Interrupt 1 subpriority */
-#define PIC32_IPC_IP1(x)	((x)<<10)	/* Interrupt 1 priority */
-#define PIC32_IPC_IS2(x)	((x)<<16)	/* Interrupt 2 subpriority */
-#define PIC32_IPC_IP2(x)	((x)<<18)	/* Interrupt 2 priority */
-#define PIC32_IPC_IS3(x)	((x)<<24)	/* Interrupt 3 subpriority */
-#define PIC32_IPC_IP3(x)	((x)<<26)	/* Interrupt 3 priority */
+#define PIC32_IPC_IS0(x)    (x)     /* Interrupt 0 subpriority */
+#define PIC32_IPC_IP0(x)    ((x)<<2)    /* Interrupt 0 priority */
+#define PIC32_IPC_IS1(x)    ((x)<<8)    /* Interrupt 1 subpriority */
+#define PIC32_IPC_IP1(x)    ((x)<<10)   /* Interrupt 1 priority */
+#define PIC32_IPC_IS2(x)    ((x)<<16)   /* Interrupt 2 subpriority */
+#define PIC32_IPC_IP2(x)    ((x)<<18)   /* Interrupt 2 priority */
+#define PIC32_IPC_IS3(x)    ((x)<<24)   /* Interrupt 3 subpriority */
+#define PIC32_IPC_IP3(x)    ((x)<<26)   /* Interrupt 3 priority */
 
 /*
  * IRQ numbers for PIC32MZ
@@ -1563,7 +1563,7 @@
 #define PIC32_IRQ_IC9       42  /* Input Capture 9 */
 #define PIC32_IRQ_OC9       43  /* Output Compare 9 */
 #define PIC32_IRQ_AD1       44  /* ADC1 Global Interrupt */
-                         /* 45  -- Reserved */
+/* 45  -- Reserved */
 #define PIC32_IRQ_AD1DC1    46  /* ADC1 Digital Comparator 1 */
 #define PIC32_IRQ_AD1DC2    47  /* ADC1 Digital Comparator 2 */
 #define PIC32_IRQ_AD1DC3    48  /* ADC1 Digital Comparator 3 */
@@ -1576,7 +1576,7 @@
 #define PIC32_IRQ_AD1DF4    55  /* ADC1 Digital Filter 4 */
 #define PIC32_IRQ_AD1DF5    56  /* ADC1 Digital Filter 5 */
 #define PIC32_IRQ_AD1DF6    57  /* ADC1 Digital Filter 6 */
-                         /* 58  -- Reserved */
+/* 58  -- Reserved */
 #define PIC32_IRQ_AD1D0     59  /* ADC1 Data 0 */
 #define PIC32_IRQ_AD1D1     60  /* ADC1 Data 1 */
 #define PIC32_IRQ_AD1D2     61  /* ADC1 Data 2 */
@@ -1626,7 +1626,7 @@
 #define PIC32_IRQ_CFDC      105 /* Core Fast Debug Channel */
 #define PIC32_IRQ_SB        106 /* System Bus Protection Violation */
 #define PIC32_IRQ_CRPT      107 /* Crypto Engine Event */
-                         /* 108 -- Reserved */
+/* 108 -- Reserved */
 #define PIC32_IRQ_SPI1E     109 /* SPI1 Fault */
 #define PIC32_IRQ_SPI1RX    110 /* SPI1 Receive Done */
 #define PIC32_IRQ_SPI1TX    111 /* SPI1 Transfer Done */
@@ -1709,7 +1709,7 @@
 #define PIC32_IRQ_U6E       188 /* UART6 Fault */
 #define PIC32_IRQ_U6RX      189 /* UART6 Receive Done */
 #define PIC32_IRQ_U6TX      190 /* UART6 Transfer Done */
-                         /* 191 -- Reserved */
+/* 191 -- Reserved */
 #define PIC32_IRQ_LAST      190 /* Last valid irq number */
 
 #endif /* _IO_PIC32MZ_H */

--- a/interrupts.c
+++ b/interrupts.c
@@ -5,7 +5,8 @@
 /* Provided by linker script. */
 extern const char __ebase[];
 
-void intr_init(){
+void intr_init()
+{
 
     /* PIC32 provides various interrupt modes it can be configured to
      * use. Because of QEMU limits, the configuration we use is to
@@ -61,10 +62,11 @@ void intr_init(){
     mtc0(C0_STATUS, 0, status);
 }
 
-void intr_dispatcher(){
+void intr_dispatcher()
+{
     unsigned irq_n = PIC32_INTSTAT_VEC(INTSTAT);
     /* Recognize interrupt type. */
-    switch(irq_n){
+    switch(irq_n) {
     case PIC32_IRQ_CT:
         /* Core timer interrupt. */
         hardclock();

--- a/kmem.c
+++ b/kmem.c
@@ -9,7 +9,8 @@ extern char __ebss[];
  * It shall be always word-aligned. See km_early_alloc for details. */
 static uintptr_t km_kernel_image_end = (uintptr_t)__ebss;
 
-void* km_early_alloc(size_t size){
+void* km_early_alloc(size_t size)
+{
     // TODO: Explicitly crash if this function is called after
     // physical memory manager has been initialized.
     void* ptr = (void*)km_kernel_image_end;

--- a/main.c
+++ b/main.c
@@ -97,7 +97,7 @@ int kernel_main()
     while(p < empty + sizeof(empty))
         if(*p++ != 0x00)
             kprintf("Apparently .bss was not cleared!\n");
-            // TODO: Exit main? Ignore?
+    // TODO: Exit main? Ignore?
 
     /*
      * Print initial state of control registers.

--- a/smallclib/kprintf.c
+++ b/smallclib/kprintf.c
@@ -3,7 +3,8 @@
 #include <low/_stdio.h>
 #include "uart_raw.h"
 
-int __low_kprintf (ReadWriteInfo *rw __attribute__((unused)), const void *src, size_t len)
+int __low_kprintf (ReadWriteInfo *rw __attribute__((unused)), const void *src,
+                   size_t len)
 {
     return uart_write(src,len);
 }

--- a/smallclib/snprintf.c
+++ b/smallclib/snprintf.c
@@ -4,25 +4,23 @@
 
 int __low_snprintf (ReadWriteInfo *rw, const void *src, size_t len)
 {
-  int ret, maxbytes = 0;
-  char *dst;
-  const char *src0 = (const char *) src;
+    int ret, maxbytes = 0;
+    char *dst;
+    const char *src0 = (const char *) src;
 
-  if (len && rw->m_handle)
-    {
-      maxbytes = MIN ((rw->m_limit - rw->m_size)-1, len);
-      ret = maxbytes;
-      dst = (char*)(rw->m_handle + rw->m_size);
-      while (maxbytes)
-      {
-        *dst++ = *src0++;
-        --maxbytes;
-      }
-      //memcpy (rw->m_handle + rw->m_size, src, maxbytes);
-      rw->m_size += ret;
+    if (len && rw->m_handle) {
+        maxbytes = MIN ((rw->m_limit - rw->m_size)-1, len);
+        ret = maxbytes;
+        dst = (char*)(rw->m_handle + rw->m_size);
+        while (maxbytes) {
+            *dst++ = *src0++;
+            --maxbytes;
+        }
+        //memcpy (rw->m_handle + rw->m_size, src, maxbytes);
+        rw->m_size += ret;
     }
 
-  return len;
+    return len;
 }
 
 /* This custom snprintf does not use any floating point calculations,
@@ -42,6 +40,6 @@ int snprintf (char *str, size_t size, const char *fmt, ...)
 
     /* terminate the string */
     if (rw.m_handle)
-      *((char *)rw.m_handle + rw.m_size) = '\0';
+        *((char *)rw.m_handle + rw.m_size) = '\0';
     return ret;
 }

--- a/smallclib/wctomb.c
+++ b/smallclib/wctomb.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 
-int wctomb (char *s, wchar_t wchar __attribute__((unused))) {
+int wctomb (char *s, wchar_t wchar __attribute__((unused)))
+{
     return (s == NULL) ? 0 : -1;
 }

--- a/uart_raw.c
+++ b/uart_raw.c
@@ -4,7 +4,8 @@
 #include "common.h"
 #include "global_config.h"
 
-void uart_init(){
+void uart_init()
+{
     /* Initialize UART. */
     U1RXR = 2;                          /* assign UART1 receive to pin RPF4 */
     RPF5R = 1;                          /* assign pin RPF5 to UART1 transmit */
@@ -18,7 +19,8 @@ void uart_init(){
 
 }
 
-int uart_putc(int c){
+int uart_putc(int c)
+{
     /* Wait for transmitter shift register empty. */
     while (! (U1STA & PIC32_USTA_TRMT))
         continue;
@@ -37,9 +39,10 @@ again:
     return c;
 }
 
-int uart_puts(const char* str){
+int uart_puts(const char* str)
+{
     int n = 0;
-    while(*str){
+    while(*str) {
         uart_putc(*str++);
         n++;
     }
@@ -47,13 +50,15 @@ int uart_puts(const char* str){
     return n + 1;
 }
 
-int uart_write(const char* str, size_t n){
+int uart_write(const char* str, size_t n)
+{
     while(n--) uart_putc(*str++);
     return n;
 }
 
-unsigned char uart_getch(){
-      unsigned c;
+unsigned char uart_getch()
+{
+    unsigned c;
 
     for (;;) {
         /* Wait until receive data available. */


### PR DESCRIPTION
In this branch, I propose a set of options for astyle that will unify code formatting style. The options are listed in `astyle.options`, each with brief explanation. I have chosen the options so that the current formatting of source files matches the options most closely. Turns out `k&r` style is mostly correct.

The command for running astyle with these options is

    astyle --options=astyle.options --recursive "*.h" "*.c"

and it is also listed, for convenience, inside `astyle.options`. We may consider hooking it so that it always runs before `git commit`, but it must be kept in mind that as it is not a standard tool, it may be not installed on the particular machine.

The second commit applies the proposed formatting to all source files. Clearly, the `pic32mz.h` file was an utter tabs/spaces mess, so the fix for that takes up 90% of the entire diff.