### PR TITLE
Context switching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDLIBS   = smallclib/smallclib.a
 
 PROGNAME = main
 SOURCES_C = main.c uart_raw.c interrupts.c clock.c bitmap.c kmem.c
-SOURCES_ASM = startup.S intr.S init_gpr.S init_cp0.S init_caches.S init_tlb.S
+SOURCES_ASM = startup.S intr.S init_gpr.S init_cp0.S init_caches.S init_tlb.S context.S
 SOURCES = $(SOURCES_C) $(SOURCES_ASM)
 OBJECTS = $(SOURCES_C:.c=.o) $(SOURCES_ASM:.S=.o)
 DEPFILES = $(SOURCES_C:%.c=.%.D) $(SOURCES_ASM:%.S=.%.D)

--- a/context.S
+++ b/context.S
@@ -1,0 +1,50 @@
+#include "asm.h"
+
+    .set noreorder  // Disable automatic instruction reordering
+
+
+/* uint32_t ctx_store(struct ctx_struct* ctx) */
+LEAF(ctx_store)
+
+    sw $ra, ( 0*4)($a0)
+    sw $sp, ( 1*4)($a0)
+    sw $gp, ( 2*4)($a0)
+    sw $s0, ( 3*4)($a0)
+    sw $s1, ( 4*4)($a0)
+    sw $s2, ( 5*4)($a0)
+    sw $s3, ( 6*4)($a0)
+    sw $s4, ( 7*4)($a0)
+    sw $s5, ( 8*4)($a0)
+    sw $s6, ( 9*4)($a0)
+    sw $s7, (10*4)($a0)
+    sw $s8, (11*4)($a0)
+
+    /* Return 0 */
+    jr $ra
+    move $v0, $zero
+END(ctx_store)
+
+
+/* void ctx_load(const struct ctx_struct* ctx) */
+LEAF(ctx_load)
+
+    lw $ra, ( 0*4)($a0)
+    lw $sp, ( 1*4)($a0)
+    lw $gp, ( 2*4)($a0)
+    lw $s0, ( 3*4)($a0)
+    lw $s1, ( 4*4)($a0)
+    lw $s2, ( 5*4)($a0)
+    lw $s3, ( 6*4)($a0)
+    lw $s4, ( 7*4)($a0)
+    lw $s5, ( 8*4)($a0)
+    lw $s6, ( 9*4)($a0)
+    lw $s7, (10*4)($a0)
+    lw $s8, (11*4)($a0)
+
+    /* Note that the following will not return from ctx_load, because
+	 * $ra has been overwritten with the value previously stored by
+     * ctx_store. Instead, it resumes the context, and returns 1
+     * there.*/
+    jr $ra
+    li $v0, 1
+END(ctx_load)

--- a/include/context.h
+++ b/include/context.h
@@ -35,4 +35,24 @@ uint32_t ctx_store(struct ctx_struct* ctx) __attribute__((warn_unused_result));
  */
 void ctx_load(const struct ctx_struct* ctx) __attribute__((noreturn));
 
+/* This function modifies a saved context so that it immediatelly
+ * enters a particular function when the context is resumed. This is
+ * done by modifying the stored return address to the given target
+ * function. This may be useful for creating execution contexts that
+ * start in a separate procedure.
+ *
+ * WARNING: The target procedure MUST NOT RETURN. The result of doing
+ * so is undefined, but will generally restart the target function.
+ */
+inline void ctx_set_addr(struct ctx_struct* ctx, void (*target)())
+{
+    ctx->registers[0] = (uintptr_t)target;
+}
+
+/* Sets the stack pointer in a stored context struct */
+inline void ctx_set_stack(struct ctx_struct* ctx, void *stack)
+{
+    ctx->registers[1] = (uintptr_t)stack;
+}
+
 #endif // __CONTEXT_H__

--- a/include/context.h
+++ b/include/context.h
@@ -2,6 +2,7 @@
 #define __CONTEXT_H__
 
 #include "common.h"
+#include "libkern.h"
 #include <stddef.h>
 
 struct ctx_struct{
@@ -53,6 +54,22 @@ inline void ctx_set_addr(struct ctx_struct* ctx, void (*target)())
 inline void ctx_set_stack(struct ctx_struct* ctx, void *stack)
 {
     ctx->registers[1] = (uintptr_t)stack;
+}
+
+/* This function sets the contents of a context struct, zeroing it's
+ * all registers except for return address, which is set to @target,
+ * stack pointer, which is set to @stack, and global pointer, which is
+ * set to @gp.
+ *
+ * WARNING: The target procedure MUST NOT RETURN. The result of such
+ * event is undefined, but will generally restart the target function.
+ */
+inline void ctx_create(struct ctx_struct* ctx, void (*target)(), void* stack, void* gp)
+{
+    bzero(ctx, sizeof(struct ctx_struct));
+    ctx->registers[0] = (uintptr_t)target;
+    ctx->registers[1] = (uintptr_t)stack;
+    ctx->registers[2] = (uintptr_t)gp;
 }
 
 /* This function stores the current context to @from, and resumes the

--- a/include/context.h
+++ b/include/context.h
@@ -1,0 +1,38 @@
+#ifndef __CONTEXT_H__
+#define __CONTEXT_H__
+
+#include "common.h"
+#include <stddef.h>
+
+struct ctx_struct{
+    /* Registers stored (in that particular order):
+     *
+     * ra
+     * sp
+     * gp
+     * s0 s1 s2 s3 s4 s5 s6 s7 s8
+     *
+     * Since context-saving procedures work as function calls, several
+     * registers do not require saving because they are not saved by
+     * called functions anyway. This includes:
+     * a0-a3, v0-v1, t0-t9, k0-k1
+     *
+     * The program counter does not require storing, because the
+     * context restoring procedures work as function calls, so it is
+     * sufficient to replace the return address register.
+     */
+    word_t registers[12];
+};
+
+/* Stores the current execution context to the given structure.
+ * Returns 0 when returning directly, or 1 when returning as a result
+ * of ctx_load.
+ */
+uint32_t ctx_store(struct ctx_struct* ctx) __attribute__((warn_unused_result));
+
+/* Restores a previously stored context. This function does not
+ * return. The control flow jumps to the corresponding ctx_store.
+ */
+void ctx_load(const struct ctx_struct* ctx) __attribute__((noreturn));
+
+#endif // __CONTEXT_H__

--- a/include/context.h
+++ b/include/context.h
@@ -55,4 +55,13 @@ inline void ctx_set_stack(struct ctx_struct* ctx, void *stack)
     ctx->registers[1] = (uintptr_t)stack;
 }
 
+/* This function stores the current context to @from, and resumes the
+ * context stored in @to. It does not return immediatelly, it returns
+ * only when the @from context is resumed. */
+inline void ctx_switch(struct ctx_struct* from, struct ctx_struct* to)
+{
+    if(!ctx_store(from))
+        ctx_load(to);
+}
+
 #endif // __CONTEXT_H__


### PR DESCRIPTION
Linked to #9.

The interface defined in `context.h` is pretty straight-forward. The `demo_ctx` I temporarily added to `main.c` is probably fancy enough.

I do not like the name of the main structure `ctx_struct` though, but I did not want to name it `ctx` or `context`. Any thoughts?